### PR TITLE
Docs badges: add intro.html to the url

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ image.
 
 Read the documentation here:
 
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaImages.github.io/ImageMetadata.jl/stable)
-[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://JuliaImages.github.io/ImageMetadata.jl/latest)
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaImages.github.io/ImageMetadata.jl/stable/intro.html)
+[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://JuliaImages.github.io/ImageMetadata.jl/latest/intro.html)


### PR DESCRIPTION
The standard badge assumes that the lead-off file will be called index.html.

We could alternatively rename the page `index.md`, but this seemed easier.
