### PR TITLE
Extended indexing always returns an ImageMeta

### DIFF
--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -77,16 +77,12 @@ through Julia's type system.  However, functions that receive an
 in your own code it's fine to use properties to your advantage for
 custom tasks.
 
-### getindexim/viewim
+### Vector indexing (region-of-interest selection)
 
-As with the rest of julia, `img[i,j,...]` will return just the values
-in an `ImageMeta`; the properties dictionary is "left behind." You can
-ensure that the return is also an `ImageMeta` using `getindexim`
-instead of `getindex` (`img[i,j]` gets converted into `getindex(img,
-i, j)`, hence the name):
+When indexing over an extended area, `img[i,j,...]` returns an `ImageMeta`:
 
 ```julia
-julia> c = getindexim(img, 1:2, 1:2)
+julia> c = img[1:2, 1:2]
 RGB ImageMeta with:
   data: 2×2 Array{ColorTypes.RGB{FixedPointNumbers.Normed{UInt8,8}},2}
   properties:
@@ -97,7 +93,7 @@ RGB ImageMeta with:
 This copies both the data (just the relevant portions) and the properties dictionary. In contrast,
 
 ```julia
-julia> v = viewim(img, 1:2, 1:2)
+julia> v = view(img, 1:2, 1:2)
 RGB ImageMeta with:
   data: 2×2 SubArray{ColorTypes.RGB{FixedPointNumbers.Normed{UInt8,8}},2,Array{ColorTypes.RGB{FixedPointNumbers.Normed{UInt8,8}},2},Tuple{UnitRange{Int64},UnitRange{Int64}},false}
   properties:

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -19,11 +19,9 @@ export
     # functions
     copyproperties,
     data,
-    getindexim,
     properties,
     shareproperties,
-    spatialproperties,
-    viewim
+    spatialproperties
 
 #### types and constructors ####
 
@@ -91,10 +89,10 @@ for AType in (ImageMeta, ImageMetaAxis)
 end
 
 @inline function Base.getindex(img::ImageMetaAxis, ax::Axis, I...)
-    img.data[ax, I...]
+    copyproperties(img, img.data[ax, I...])
 end
 @inline function Base.getindex(img::ImageMetaAxis, i::Union{Integer,AbstractVector,Colon}, I...)
-    img.data[i, I...]
+    copyproperties(img, img.data[i, I...])
 end
 
 @inline function Base.setindex!(img::ImageMetaAxis, val, ax::Axis, I...)
@@ -104,10 +102,10 @@ end
     setindex!(img.data, val, i, I...)
 end
 
-Base.view(img::ImageMetaAxis, ax::Axis, I...) = view(img.data, ax, I...)
-Base.view{T,N}(img::ImageMetaAxis{T,N}, I::Vararg{ViewIndex,N}) = view(img.data, I...)
-Base.view(img::ImageMetaAxis, i::ViewIndex) = view(img.data, i)
-Base.view{N}(img::ImageMetaAxis, I::Vararg{ViewIndex,N}) = view(img.data, I...)
+Base.view(img::ImageMeta, ax::Axis, I...) = shareproperties(img, view(img.data, ax, I...))
+Base.view{T,N}(img::ImageMeta{T,N}, I::Vararg{ViewIndex,N}) = shareproperties(img, view(img.data, I...))
+Base.view(img::ImageMeta, i::ViewIndex) = shareproperties(img, view(img.data, i))
+Base.view{N}(img::ImageMeta, I::Vararg{ViewIndex,N}) = shareproperties(img, view(img.data, I...))
 
 Base.getindex(img::ImageMeta, propname::AbstractString) = img.properties[propname]
 
@@ -159,29 +157,6 @@ shareproperties(img::ImageMeta, data::AbstractArray) = ImageMeta(data, img.prope
 
 # Delete a property!
 Base.delete!(img::ImageMeta, propname::AbstractString) = delete!(img.properties, propname)
-
-"""
-    getindexim(img::ImageMeta, I...) -> newimg
-
-Like `img[I...]`, except that the returned `newimg` is another
-ImageMeta. Like the data component, the properties dictionary of `img`
-is copied, so `newimg` is not linked in any way to `img`.
-
-See also: [`viewim`](@ref).
-"""
-getindexim(img::ImageMeta, I...) = copyproperties(img, img.data[I...])
-
-"""
-    viewim(img::ImageMeta, I...) -> newimg
-
-Like `view(img, I...)`, except that the returned `newimg` is another
-ImageMeta. Like the data component, the properties dictionary of `img`
-is shared with `img`, so that changes to either the data or the
-properties apply to both.
-
-See also: [`getindexim`](@ref).
-"""
-viewim(img::ImageMeta, I...) = shareproperties(img, view(img.data, I...))
 
 # Iteration
 # Defer to the array object in case it has special iteration defined

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -14,13 +14,13 @@ Base.@deprecate_binding AbstractImageIndexed ImageMetaIndirect
 @deprecate ImageCmap(data, cmap; kwargs...)  ImageMeta(IndirectArray(data, cmap); kwargs...)
 @deprecate ImageCmap(data, cmap, properties) ImageMeta(IndirectArray(data, cmap), properties)
 
-Base.@deprecate_binding sliceim viewim
+Base.@deprecate_binding sliceim view
 
 function subim(img::Union{AxisArray,ImageMeta}, args...)
     newargs = _subim_indexes(args)
     newargstr = join(map(string, newargs), ", ")
-    Base.depwarn("subim is deprecated, call viewim(img, $newargstr) instead", :subim)
-    viewim(img, newargs...)
+    Base.depwarn("subim is deprecated, call view(img, $newargstr) instead", :subim)
+    view(img, newargs...)
 end
 export subim
 
@@ -48,20 +48,12 @@ using ImageAxes: getaxes
 function Base.view(img::ImageMetaAxis, dimname::AbstractString, ind::Base.ViewIndex, args...)
     axs = getaxes(dimname, ind, args...)
     Base.depwarn("indexing with strings is deprecated, use view(img, $(axs...)) instead", :view!)
-    view(img.data, axs...)
-end
-
-function viewim(img::ImageMetaAxis, dimname::AbstractString, ind::Base.ViewIndex, args...)
-    axs = getaxes(dimname, ind, args...)
-    Base.depwarn("indexing with strings is deprecated, use view(img, $(axs...)) instead", :view!)
     shareproperties(img, view(img.data, axs...))
 end
 
 @deprecate copyproperties(img::AbstractArray, data::AbstractArray) data
 @deprecate shareproperties(img::AbstractArray, data::AbstractArray) data
 
-@deprecate getindexim(img::AbstractArray, I...) img[I...]
-@deprecate viewim(img::AbstractArray, I...) view(img, I...)
 
 #### Properties ####
 
@@ -152,3 +144,6 @@ import ImageAxes.storageorder
 @deprecate real(img::ImageMeta) shareproperties(img,real.(data(img)))
 @deprecate imag(img::ImageMeta) shareproperties(img,imag.(data(img)))
 @deprecate abs(img::ImageMeta) shareproperties(img,abs.(data(img)))
+
+@deprecate getindexim getindex
+@deprecate viewim view

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -70,6 +70,13 @@ msg_contains(pass, msg) = contains(pass.value.msg, msg) || error(pass.value.msg,
             msg_contains(result, "data, :boo, :rah")
         end
     end
+
+    @testset "getindexim/viewim" begin
+        img = ImageMeta(rand(3,5); prop1 = 1, prop2 = [1,2,3])
+        @test !isempty(properties(img))
+        @test isa(viewim(img, 1:2, 1:2), ImageMeta)
+        @test isa(getindexim(img, 1:2, 1:2), ImageMeta)
+    end
 end
 
 nothing


### PR DESCRIPTION
This implements the functionality decided on in #11. Anyone who receives a performance hit from this can always use `data` on the parent image.

I'm quite happy with the de-uglification of the API.