### PR TITLE
Fix errors and depwarns on 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ Colors
 ColorVectorSpace 0.1.11
 ImageCore
 ImageAxes
+Compat 0.19

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -8,7 +8,7 @@ import Base: sqrt, atan2, hypot, real, imag, abs
 Base.@deprecate_binding Image ImageMeta
 Base.@deprecate_binding AbstractImage ImageMeta
 Base.@deprecate_binding AbstractImageDirect ImageMeta
-typealias ImageMetaIndirect{T,N,A<:IndirectArray} ImageMeta{T,N,A}
+@compat const ImageMetaIndirect{T,N,A<:IndirectArray} = ImageMeta{T,N,A}
 Base.@deprecate_binding AbstractImageIndexed ImageMetaIndirect
 
 @deprecate ImageCmap(data, cmap; kwargs...)  ImageMeta(IndirectArray(data, cmap); kwargs...)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -1,8 +1,46 @@
 using ColorVectorSpace: AbstractGray, TransparentGray, TransparentRGB
 
+const dotops = VERSION < v"0.6.0-dev.1839"
+
+if isdefined(Base.Broadcast, :containertype)
+    # Specialize the low-level broadcasting machinery for ImageMeta.
+    # This make it work for all operators, rather than specializing
+    # each operator individually.
+    using Base.Broadcast: _broadcast_eltype, broadcast_indices
+    Base.Broadcast._containertype(::Type{<:ImageMeta}) = ImageMeta
+    Base.Broadcast.promote_containertype(::Type{ImageMeta}, ::Type{ImageMeta}) = ImageMeta
+    Base.Broadcast.promote_containertype(::Type{Array}, ::Type{ImageMeta}) = ImageMeta
+    Base.Broadcast.promote_containertype(::Type{ImageMeta}, ::Type{Array}) = ImageMeta
+    Base.Broadcast.promote_containertype(::Type{ImageMeta}, ct) = ImageMeta
+    Base.Broadcast.promote_containertype(ct, ::Type{ImageMeta}) = ImageMeta
+    Base.Broadcast.broadcast_indices(::Type{ImageMeta}, A) = indices(A)
+    function Base.Broadcast.broadcast_c(f, ::Type{ImageMeta}, As...)
+        T = _broadcast_eltype(f, As...)
+        shape = broadcast_indices(As...)
+        Mt = imagemeta(As...)
+        length(Mt) == 1 || return ambigop(Symbol(f))
+        M = Mt[1]
+        broadcast!(f, shareproperties(M, similar(data(M), T, shape)), As...)
+    end
+    # Select all the ImageMeta arrays
+    @inline imagemeta(As...) = _imagemeta((), As...)
+    _imagemeta(out) = out
+    @inline _imagemeta(out, A::ImageMeta, As...) = _imagemeta((out..., A), As...)
+    @inline _imagemeta(out, A, As...) = _imagemeta(out, As...)
+end
+
+if dotops
+    import Base: .+, .-, .*, ./, .^, .<, .>, .==
+    batch1 = (:+, :.+, :-, :.-, :*, :.*)
+    batch2 = (:+, :.+, :-, :.-)
+else
+    batch1 = (:+, :-, :*)
+    batch2 = (:+, :-)
+end
+
 (-)(img::ImageMeta) = shareproperties(img, -data(img))
 
-for op in (:+, :.+, :-, :.-, :*, :.*)
+for op in batch1
     @eval begin
         ($op)(img::ImageMeta{Bool}, n::Bool) = shareproperties(img, ($op)(data(img), n))
         ($op)(n::Bool, img::ImageMeta{Bool}) = shareproperties(img, ($op)(n, data(img)))
@@ -20,7 +58,7 @@ for op in (:+, :.+, :-, :.-, :*, :.*)
     end
 end
 
-for op in (:+, :.+, :-, :.-)
+for op in batch2
     for CV in (:AbstractGray, :TransparentGray, :AbstractRGB, :TransparentRGB)
         @eval begin
             ($op){CV<:$CV}(img::ImageMeta{CV}, n::$CV) =
@@ -32,19 +70,25 @@ for op in (:+, :.+, :-, :.-)
 end
 
 (/)(img::ImageMeta, n::Number) = shareproperties(img, data(img)/n)
-(./)(img::ImageMeta, A::BitArray) = shareproperties(img, data(img)./A)  # needed to avoid ambiguity warning
-(./)(img1::ImageMeta, img2::ImageMeta) = ambigop(:./)
-(./)(img::ImageMeta, A::AbstractArray) = shareproperties(img, data(img)./A)
-(.^)(img::ImageMeta, p::Number) = shareproperties(img, data(img).^p)
 
-# Logical operations
-(.<)(img::ImageMeta, n::Number) = data(img) .< n
-(.>)(img::ImageMeta, n::Number) = data(img) .> n
-(.<)(img::ImageMeta{Bool}, A::AbstractArray{Bool}) = data(img) .< A
-(.<)(img::ImageMeta, A::AbstractArray) = data(img) .< A
-(.>)(img::ImageMeta, A::AbstractArray) = data(img) .> A
-(.==)(img::ImageMeta, n::Number) = data(img) .== n
-(.==)(img::ImageMeta{Bool}, A::AbstractArray{Bool}) = data(img) .== A
-(.==)(img::ImageMeta, A::AbstractArray) = data(img) .== A
+if dotops
+    # evaling in a string avoids a parser depwarn
+    include_string("""
+    (./)(img::ImageMeta, A::BitArray) = shareproperties(img, data(img)./A)  # needed to avoid ambiguity warning
+    (./)(img1::ImageMeta, img2::ImageMeta) = ambigop(:./)
+    (./)(img::ImageMeta, A::AbstractArray) = shareproperties(img, data(img)./A)
+    (.^)(img::ImageMeta, p::Number) = shareproperties(img, data(img).^p)
+
+    # Logical operations
+    (.<)(img::ImageMeta, n::Number) = data(img) .< n
+    (.>)(img::ImageMeta, n::Number) = data(img) .> n
+    (.<)(img::ImageMeta{Bool}, A::AbstractArray{Bool}) = data(img) .< A
+    (.<)(img::ImageMeta, A::AbstractArray) = data(img) .< A
+    (.>)(img::ImageMeta, A::AbstractArray) = data(img) .> A
+    (.==)(img::ImageMeta, n::Number) = data(img) .== n
+    (.==)(img::ImageMeta{Bool}, A::AbstractArray{Bool}) = data(img) .== A
+    (.==)(img::ImageMeta, A::AbstractArray) = data(img) .== A
+    """)
+end
 
 ambigop(s::Symbol) = error("$s with two ImageMeta arrays: dictionary choice is ambiguous")

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,4 +1,5 @@
 using FixedPointNumbers, Colors, ColorVectorSpace, SimpleTraits, ImageAxes, ImageMetadata
+using Compat
 using Base.Test
 
 @testset "indexing" begin
@@ -10,7 +11,7 @@ using Base.Test
              rand(Gray{N0f8}, 3))
         img = ImageMeta(A, prop1=1, prop2=[1,2,3])
         @test eltype(img) == eltype(A)
-        @test Base.linearindexing(img) == Base.linearindexing(A)
+        @test IndexStyle(img) == IndexStyle(A)
         @test ndims(img) == 1
         @test size(img) == (3,)
         @test data(img) === A
@@ -44,7 +45,7 @@ using Base.Test
               rand(Gray{Float32}, 3, 5))
         img = ImageMeta(A, prop1=1, prop2=[1,2,3]) # TODO: add @inferred (see julia #17719)
         @test eltype(img) == eltype(A)
-        @test Base.linearindexing(img) == Base.linearindexing(A)
+        @test IndexStyle(img) == IndexStyle(A)
         @test ndims(img) == 2
         @test size(img) == (3,5)
         @test data(img) === A
@@ -266,20 +267,18 @@ end
 @testset "show" begin
     for supp in (Set(["prop3"]), "prop3")
         img = ImageMeta(rand(3,5); prop1 = 1, prop2 = [1,2,3], suppress = supp, prop3 = "hide")
-        io = IOBuffer()
-        show(io, img)
-        str = takebuf_string(io)
+        str = string(img)
         @test contains(str, "ImageMeta with")
         @test contains(str, "prop1")
         @test contains(str, "prop2")
-        @test contains(str, "[1,2,3]")
+        @test contains(str, "$([1,2,3])")
         @test contains(str, "prop3")
         @test !contains(str, "hide")
         @test contains(str, "<suppressed>")
         @test !contains(str, "suppress:")
         io = IOBuffer()
         show(io, MIME("text/plain"), img)
-        str2 = takebuf_string(io)
+        str2 = String(take!(io))
         @test str == str2
     end
 end

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -9,29 +9,34 @@ using ImageMetadata, FixedPointNumbers, Colors, ColorVectorSpace, Base.Test
     for A in (rand(Bool, 3, 5), rand(3, 5),
               rand(Gray{N0f8}, 3, 5), rand(RGB{N0f8}, 3, 5))
         M = ImageMeta(A)
+        M2 = similar(M)
         checkmeta(-M, -A)
         checkmeta(M + zero(eltype(M)), M)
         checkmeta(zero(eltype(M)) + M, M)
         checkmeta(M - zero(eltype(M)), M)
         checkmeta(zero(eltype(M)) - M, -M)
         B = falses(size(M))
-        for op in (+, .+)
-            if !(eltype(A) <: RGB)
-                checkmeta(op(M, B), M)
-                checkmeta(op(B, M), M)
-            end
-            @test_throws ErrorException op(M, M)
-            checkmeta(op(A, M), A+A)
-            checkmeta(op(M, A), A+A)
-        end
-        for op in (-, .-)
-            if !(eltype(A) <: RGB)
-                checkmeta(op(M, B), M)
-                checkmeta(op(B, M), -M)
-            end
-            @test_throws ErrorException op(M, M)
-            checkmeta(op(A, M), 0*M)
-            checkmeta(op(M, A), 0*M)
+        if !(eltype(A) <: RGB)
+            checkmeta(M + B, M)
+            checkmeta(M .+ B, M)
+            checkmeta(B + M, M)
+            checkmeta(B .+ M, M)
+            @test_throws ErrorException M + M2
+            @test_throws ErrorException M .+ M2
+            checkmeta(A + M, A+A)
+            checkmeta(A .+ M, A+A)
+            checkmeta(M + A, A+A)
+            checkmeta(M .+ A, A+A)
+            checkmeta(M - B, M)
+            checkmeta(M .- B, M)
+            checkmeta(B - M, -M)
+            checkmeta(B .- M, -M)
+            @test_throws ErrorException M - M2
+            @test_throws ErrorException M .- M2
+            checkmeta(A - M, 0*M)
+            checkmeta(A .- M, 0*M)
+            checkmeta(M - A, 0*M)
+            checkmeta(M .- A, 0*M)
         end
         checkmeta(M*2, 2*M)
         checkmeta(2.*M, 2*M)
@@ -41,14 +46,14 @@ using ImageMetadata, FixedPointNumbers, Colors, ColorVectorSpace, Base.Test
         checkmeta(M.*B, 0*M)
         checkmeta(B.*M, 0*M)
         if !(eltype(A) <: RGB)
-            @test_throws ErrorException M.*M
+            @test_throws ErrorException M.*M2
             checkmeta(A.*M, A.*A)
             checkmeta(M.*A, A.*A)
             checkmeta(M.^1, M)
         end
         B1 = trues(size(M))
         checkmeta(M./B1, M)
-        @test_throws ErrorException M./M
+        @test_throws ErrorException M./M2
         if !(eltype(A) <: RGB)
             checkmeta(M + 0.0, M)
             checkmeta(0.0 + M, M)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,9 @@
 using ImageMetadata
 using Base.Test
 
-@test isempty(detect_ambiguities(ImageMetadata,ImageAxes,ImageCore,IndirectArrays,Base,Core))
+if VERSION < v"0.6.0-dev"
+    @test isempty(detect_ambiguities(ImageMetadata,ImageAxes,ImageCore,IndirectArrays,Base,Core))
+end
 
 include("core.jl")
 include("operations.jl")


### PR DESCRIPTION
The most important change is to broadcasting. One surprise here was how `M .+ M` behaved differently than `M .+ M2`; the former is implemented by rewriting the function, so "broadcasting" gets passed a single array. This is insanely clever, makes certain things work on 0.6 that simply can't be allowed to work on 0.5, but also puzzled me for a good amount of time.
