### PR TITLE
Fix nesting of timeaxis

### DIFF
--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -238,6 +238,7 @@ macro get(img, k, default)
     end
 end
 
+ImageAxes.timeaxis(img::ImageMetaAxis) = timeaxis(data(img))
 ImageAxes.timedim(img::ImageMetaAxis) = timedim(data(img))
 ImageCore.colordim(img::ImageMetaAxis) = colordim(data(img))
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -300,6 +300,7 @@ end
     @test @inferred(size_spatial(img)) == (3,5)
     @test @inferred(indices_spatial(img)) == (Base.OneTo(3), Base.OneTo(5))
     assert_timedim_last(img)
+    @test timeaxis(img) == Axis{:time}(0.1:0.1:0.8)
 end
 
 @testset "spatialprops" begin


### PR DESCRIPTION
Presumably broken by https://github.com/JuliaImages/ImageCore.jl/pull/30, but this fixes it.