### PR TITLE
add StatsBase to test/REQUIRE

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 SimpleTraits
+StatsBase


### PR DESCRIPTION
this must be coming from some indirect dependency [ColorVectorSpace]
(that isn't necessarily guaranteed to always depend on StatsBase)