### PR TITLE
more fixes for v0.7/v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
       script:
         - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("ImageMetadata")'
         - julia -e 'import Pkg; Pkg.add("Documenter")'
-        - julia -e 'import ImageCore; ENV["DOCUMENTER_DEBUG"] = "true"; include(joinpath("docs","make.jl"))'
+        - julia -e 'import ImageMetadata; ENV["DOCUMENTER_DEBUG"] = "true"; include(joinpath("docs","make.jl"))'
 
 after_success:
   # push coverage results to Codecov

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -175,8 +175,7 @@ end
 Base.show(io::IO, img::ImageMeta) = showim(io, img)
 Base.show(io::IO, ::MIME"text/plain", img::ImageMeta) = showim(io, img)
 
-function ImageCore.reinterpret(::Type{T}, img::ImageMeta{T2,N,A}) where {T,T2,N,A}
-    (A <: Array) || error("reinterpret method not defined for $(typeof(img)). Consider a MappedArray instead.")
+function Base.reinterpret(::Type{T}, img::ImageMeta) where {T}
     shareproperties(img, reinterpret(T, img.data))
 end
 

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -8,7 +8,6 @@ using ColorVectorSpace   # for overriding math operations with Gray/RGB
 using Compat
 import AxisArrays
 
-import Base: +, .+, -, .-, *, .*, /, ./, .^, .<, .>, .==
 import Base: +, -, *, /
 import Base: permutedims
 
@@ -163,16 +162,8 @@ Base.delete!(img::ImageMeta, propname::AbstractString) = delete!(img.properties,
 
 # Iteration
 # Defer to the array object in case it has special iteration defined
-if isdefined(Base, :LegacyIterationCompat)
-#    Base.iterate(img::ImageMeta{Array{T,N}}, s=1) where {T,N} = iterate(data(img), s)
-#    Base.iterate(img::ImageMeta, s=(eachindex(img),)) = iterate(data(img), s)
-    Base.iterate(img::ImageMeta) = Base.iterate(data(img))
-    Base.iterate(img::ImageMeta, s) = Base.iterate(data(img), s)
-else
-Base.start(img::ImageMeta) = start(data(img))
-Base.next(img::ImageMeta, s) = next(data(img), s)
-Base.done(img::ImageMeta, s) = done(data(img), s)
-end
+Base.iterate(img::ImageMeta) = Base.iterate(data(img))
+Base.iterate(img::ImageMeta, s) = Base.iterate(data(img), s)
 
 # Show
 const emptyset = Set()
@@ -184,8 +175,11 @@ end
 Base.show(io::IO, img::ImageMeta) = showim(io, img)
 Base.show(io::IO, ::MIME"text/plain", img::ImageMeta) = showim(io, img)
 
-Base.reinterpret(::Type{T}, img::ImageMetaArray) where {T} = shareproperties(img, reinterpret(T, img.data))
-Base.reinterpret(::Type{T}, img::ImageMeta) where {T} = error("reinterpret method not defined for $(typeof(img)). Consider a MappedArray instead.")
+function ImageCore.reinterpret(::Type{T}, img::ImageMeta{T2,N,A}) where {T,T2,N,A}
+    (A <: Array) || error("reinterpret method not defined for $(typeof(img)). Consider a MappedArray instead.")
+    shareproperties(img, reinterpret(T, img.data))
+end
+
 
 """
     data(img::ImageMeta) -> array
@@ -204,6 +198,7 @@ function ImageCore.permuteddimsview(A::ImageMeta, perm)
 end
 ImageCore.channelview(A::ImageMeta) = shareproperties(A, channelview(A.data))
 ImageCore.colorview(::Type{C}, A::ImageMeta{T,N}) where {C<:Colorant,T,N} = shareproperties(A, colorview(C, A.data))
+ImageCore.colorview(::Type{ARGB32}, A::ImageMeta{T,N}) where {T,N} = shareproperties(A, colorview(ARGB32, A.data))
 ImageCore.rawview(A::ImageMeta{T}) where {T<:Real} = shareproperties(A, rawview(A.data))
 ImageCore.normedview(::Type{T}, A::ImageMeta{S}) where {T<:FixedPoint,S<:Unsigned} = shareproperties(A, normedview(T, A.data))
 
@@ -317,7 +312,14 @@ function permutedims(img::ImageMeta, perm)
     permutedims_props!(copyproperties(img, permutedims(img.data, perm)), ip)
 end
 
-Base.adjoint(img::ImageMeta{T,2}) where {T<:Real} = permutedims(img, (2,1))
+"""
+Note: `adjoint` does not recurse into ImageMeta properties.
+"""
+function Base.adjoint(img::ImageMeta{T,2}) where {T<:Real}
+    ip = sortperm([2,1][[coords_spatial(img)...]])
+    permutedims_props!(copyproperties(img, adjoint(img.data)), ip)
+end
+
 function Base.adjoint(img::ImageMeta{T,1}) where T<:Real
     check_empty_spatialproperties(img)
     copyproperties(img, img.data')

--- a/test/core.jl
+++ b/test/core.jl
@@ -130,10 +130,15 @@ end
     Mr = reinterpretc(Gray, M)
     @test eltype(Mr) == Gray{Float32}
     @test Mr["meta"] = true
-    # Ensure that it never gets defined for the un-reinterpretable
+    # Ensure that it gets defined for the formerly un-reinterpretable
+    A = zeros(Float32, 4, 5)
     M = ImageMeta(view(A, 1:2:3, 1:4), meta=true)
-    @test_throws ErrorException reinterpretc(Gray, M)
-    @test_throws ErrorException reinterpretc(Gray{Float32}, M)
+    Mr = reinterpretc(Gray, M)
+    Mr = reinterpretc(Gray{Float32}, M)
+    @test eltype(Mr) == Gray{Float32}
+    @test Mr["meta"] = true
+    Mr[:] .= Gray{Float32}(0.5)
+    @test all(A[1:2:3,1:4] .== 0.5)
 end
 
 @testset "copy/similar" begin

--- a/test/core.jl
+++ b/test/core.jl
@@ -123,18 +123,18 @@ end
     @test convert(ImageMeta{Gray}, A) == A
 end
 
-# @testset "reinterpret" begin
-#     # It's possible that reinterpret shouldn't be defined for ImageMeta, but...
-#     A = rand(Float32, 4, 5)
-#     M = ImageMeta(A, meta=true)
-#     Mr = reinterpret(Gray, M)
-#     @test eltype(Mr) == Gray{Float32}
-#     @test Mr["meta"] = true
-#     # Ensure that it never gets defined for the un-reinterpretable
-#     M = ImageMeta(view(A, 1:2:3, 1:4), meta=true)
-#     @test_throws ErrorException reinterpret(Gray, M)
-#     @test_throws ErrorException reinterpret(Gray{Float32}, M)
-# end
+@testset "reinterpret" begin
+    # It's possible that reinterpretc shouldn't be defined for ImageMeta, but...
+    A = rand(Float32, 4, 5)
+    M = ImageMeta(A, meta=true)
+    Mr = reinterpretc(Gray, M)
+    @test eltype(Mr) == Gray{Float32}
+    @test Mr["meta"] = true
+    # Ensure that it never gets defined for the un-reinterpretable
+    M = ImageMeta(view(A, 1:2:3, 1:4), meta=true)
+    @test_throws ErrorException reinterpretc(Gray, M)
+    @test_throws ErrorException reinterpretc(Gray{Float32}, M)
+end
 
 @testset "copy/similar" begin
     img = ImageMeta(rand(3,5); prop1 = 1, prop2 = [1,2,3])
@@ -264,7 +264,7 @@ end
     @test axisvalues(M) == (1:3, 1:5)
     @test M[Axis{:y}(2:3)] == A[Axis{:y}(2:3)]
     @test view(M, Axis{:y}(2:3)) == A[Axis{:y}(2:3)]
-    M[Axis{:y}(2:3), Axis{:x}(1)] = -5
+    M[Axis{:y}(2:3), Axis{:x}(1)] .= -5
     @test all(A[2:3,1] .== -5)
 end
 

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -88,7 +88,5 @@ Ms = dropdims(Mp, dims=1)
 
 img = convert(ImageMeta{Gray{N0f16}}, [0.01164 0.01118; 0.01036 0.01187])
 @test all((1 .- img) .== (1 .- img))
-@info "Two Warnings expected for test"
-@test all(1 - img .== 1 - img)
 
 nothing


### PR DESCRIPTION
This change attempts to make the adjoint method lazy,
resolves a method ambiguity, restores the reinterpretc tests,
and drops a couple of obsolete things in favor of v1.0

Note: for background on reinterpret, see [discussion in ImageCore PR](https://github.com/JuliaImages/ImageCore.jl/pull/52#issuecomment-354105830)