### PR TITLE
Test inference on Unitful AxisArrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
 jobs:
   include:
     - stage: deploy
-      julia: 0.7
+      julia: 1.0
       os: linux
       script:
         - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("ImageMetadata")'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,12 +1,12 @@
 using Documenter, ImageMetadata
 
 makedocs(modules  = [ImageMetadata],
-         format   = Documenter.Formats.HTML,
+         format   = :html,
          sitename = "ImageMetadata",
          pages    = ["intro.md", "reference.md"])
 
 deploydocs(repo   = "github.com/JuliaImages/ImageMetadata.jl.git",
-           julia  = "0.5",
+           julia  = "1.0",
            target = "build",
            deps   = nothing,
            make   = nothing)

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -6,9 +6,7 @@ data
 properties
 copyproperties
 shareproperties
-getindexim
-viewim
 spatialproperties
-ImageCore.spacedirections
+ImageMetadata.spacedirections
 permutedims
 ```

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -30,7 +30,7 @@ export
 `ImageMeta` is an AbstractArray that can have metadata, stored in a dictionary.
 
 Construct an image with `ImageMeta(A, props)` (for a properties dictionary
-`props`), or with `Image(A, prop1=val1, prop2=val2, ...)`.
+`props`), or with `ImageMeta(A, prop1=val1, prop2=val2, ...)`.
 """
 mutable struct ImageMeta{T,N,A<:AbstractArray} <: AbstractArray{T,N}
     data::A
@@ -310,9 +310,7 @@ function permutedims(img::ImageMeta, perm)
     permutedims_props!(copyproperties(img, permutedims(img.data, perm)), ip)
 end
 
-"""
-Note: `adjoint` does not recurse into ImageMeta properties.
-"""
+# Note: `adjoint` does not recurse into ImageMeta properties.
 function Base.adjoint(img::ImageMeta{T,2}) where {T<:Real}
     ip = sortperm([2,1][[coords_spatial(img)...]])
     permutedims_props!(copyproperties(img, adjoint(img.data)), ip)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,2 @@
 SimpleTraits
-
+Unitful

--- a/test/core.jl
+++ b/test/core.jl
@@ -89,11 +89,14 @@ using Unitful: m
     end
     # Test bounds-checking removal by @inbounds
     if Base.JLOptions().check_bounds != 1 && Base.JLOptions().can_inline == 1
-        a = zeros(3)
-        sizehint!(a, 10)  # make sure we don't cause a segfault
+        set5!(x) = @inbounds x[5] = 1.234
+        get5(x) = @inbounds x[5]
+        aa = zeros(3)
+        sizehint!(aa, 10)  # make sure we don't cause a segfault
+        a = ImageMeta(aa)
         @test_throws BoundsError a[5]
-        @inbounds a[5] = 1.234
-        @inbounds val = a[5]
+        set5!(a)
+        val = get5(a)
         @test val == 1.234
         a = zeros(3,5)
     end

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,7 +1,7 @@
 using FixedPointNumbers, Colors, ColorVectorSpace, SimpleTraits, ImageAxes, ImageMetadata, AxisArrays
-using Compat
 using Test
 import Dates: now
+using Unitful: m
 
 @testset "indexing" begin
     # 1d images
@@ -338,6 +338,21 @@ end
                   spatialproperties=["vector"],
                   vector=[1])
     @test_throws ErrorException M'
+end
+
+@testset "Inference" begin
+    # Heavily-nested types tax Julia's inference capabilities
+    a = rand(N2f14, 3, 5, 2)
+    a1 = a[1,1,1]
+    aa = AxisArray(a, Axis{:y}(0:2), Axis{:x}(0:4), Axis{:z}(0:1))
+    cv = colorview(RGB, aa, zeroarray, aa)
+    @test @inferred(cv[1,1,1]) == RGB(a1, zero(a1), a1)
+    au = AxisArray(a, Axis{:y}(0m:1m:2m), Axis{:x}(0m:1m:4m), Axis{:z}(0m:1m:1m))
+    cv = colorview(RGB, au, zeroarray, au)
+    @test @inferred(cv[1,1,1]) == RGB(a1, zero(a1), a1)
+    am = ImageMeta(au)
+    cv = colorview(RGB, am, zeroarray, am)
+    @inferred cv[1,1,1]
 end
 
 nothing


### PR DESCRIPTION
This test fails on julia-0.6, very nice to see it passing now.

Also fixes a test that doesn't run on CI but which fails when run locally; moreover, that test was clearly intended to test something about `ImageMeta` but instead was only testing `Array`. Also fixed.