### PR TITLE
Fix scalar CartesianIndex indexing on 0.6

### DIFF
--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -93,11 +93,16 @@ for AType in (ImageMeta, ImageMetaAxis)
 end
 
 @inline function Base.getindex(img::ImageMetaAxis, ax::Axis, I...)
-    copyproperties(img, img.data[ax, I...])
+    result = img.data[ax, I...]
+    maybe_wrap(img, result)
 end
 @inline function Base.getindex(img::ImageMetaAxis, i::Union{Integer,AbstractVector,Colon}, I...)
-    copyproperties(img, img.data[i, I...])
+    result = img.data[i, I...]
+    maybe_wrap(img, result)
 end
+maybe_wrap(img::ImageMeta{T}, result::T) where T = result
+maybe_wrap(img::ImageMeta{T}, result::AbstractArray{T}) where T = copyproperties(img, result)
+
 
 @inline function Base.setindex!(img::ImageMetaAxis, val, ax::Axis, I...)
     setindex!(img.data, val, ax, I...)

--- a/test/core.jl
+++ b/test/core.jl
@@ -331,4 +331,14 @@ end
     @test_throws ErrorException M'
 end
 
+@testset "AxisArray_CartesianIndex" begin
+    M = reshape([1,2,3,4], 2,2)
+    M = AxisArray(M)
+    img = ImageMeta(M)
+    @test 1 == img[1, CartesianIndex(1)] #Int and cartesianindex
+    @test maximum(img,2) == reshape([3,4],2,1)
+    @test mean(img,1) == reshape([1.5,3.5], 1,2)
+end
+
+
 nothing

--- a/test/core.jl
+++ b/test/core.jl
@@ -27,8 +27,8 @@ using Base.Test
         end
         img[2] = zero(eltype(img))
         @test A[2] == zero(eltype(A))
-        img[3] = one(eltype(img))
-        @test A[3] == one(eltype(A))
+        img[3] = oneunit(eltype(img))
+        @test A[3] == oneunit(eltype(A))
         @test_throws BoundsError img[0]
         @test_throws BoundsError img[4]
         @test img["prop1"] == 1
@@ -65,8 +65,8 @@ using Base.Test
         if !isa(A, typeof(reshape(1:15, 3, 5)))
             img[2,3] = zero(eltype(img))
             @test A[2,3] == zero(eltype(A))
-            img[4] = one(eltype(img))
-            @test A[4] == one(eltype(A))
+            img[4] = oneunit(eltype(img))
+            @test A[4] == oneunit(eltype(A))
         end
         @test_throws BoundsError img[0,0]
         @test_throws BoundsError img[4,1]


### PR DESCRIPTION
This is #31 against the julia-0.6 branch