### PR TITLE
Set the AxisArrays.HasAxes trait

### DIFF
--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -52,6 +52,8 @@ datatype(::Type{ImageMeta{T,N,A}}) where {T,N,A<:AbstractArray} = A
 
 Base.IndexStyle(::Type{M}) where {M<:ImageMeta} = IndexStyle(datatype(M))
 
+AxisArrays.HasAxes(A::ImageMetaAxis) = AxisArrays.HasAxes{true}()
+
 # getindex and setindex!
 for AType in (ImageMeta, ImageMetaAxis)
     @eval begin

--- a/test/core.jl
+++ b/test/core.jl
@@ -264,6 +264,7 @@ end
 @testset "meta-axes" begin
     A = AxisArray(rand(3,5), :y, :x)
     M = ImageMeta(A)
+    @test AxisArrays.HasAxes(M) == AxisArrays.HasAxes{true}()
     @test AxisArrays.axes(M) == (Axis{:y}(1:3), Axis{:x}(1:5))
     @test axisdim(M, Axis{:y}) == 1
     @test axisdim(M, Axis{:x}) == 2


### PR DESCRIPTION
This was causing a bug in NRRD, failing to write the axis spacing information.