### PR TITLE
Relax `properties` field type requirements

### DIFF
--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -231,17 +231,25 @@ Base.get(img::ImageMeta, k::AbstractString, default) = get(img.properties, k, de
 
 # So that defaults don't have to be evaluated unless they are needed,
 # we also define a @get macro (thanks Toivo Hennington):
+struct IMNothing end   # to avoid confusion in the case where dict[key] === nothing
 macro get(img, k, default)
     quote
         img, k = $(esc(img)), $(esc(k))
-        if isa(img.properties, Dict)
-            index = Base.ht_keyindex(img.properties, k)
-            (index > 0) ? img.properties.vals[index] : $(esc(default))
-        else
-            haskey(img.properties, k) ? img.properties[k] : $(esc(default))
-        end
+        val = get(img.properties, k, IMNothing())
+        return isa(val, IMNothing) ? $(esc(default)) : val
     end
 end
+#macro get(img, k, default)
+#    quote
+#        img, k = $(esc(img)), $(esc(k))
+#        if isa(img.properties, Dict)
+#            index = Base.ht_keyindex(img.properties, k)
+#            (index > 0) ? img.properties.vals[index] : $(esc(default))
+#        else
+#            haskey(img.properties, k) ? img.properties[k] : $(esc(default))
+#        end
+#    end
+#end
 
 ImageAxes.timeaxis(img::ImageMetaAxis) = timeaxis(data(img))
 ImageAxes.timedim(img::ImageMetaAxis) = timedim(data(img))

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -234,8 +234,12 @@ Base.get(img::ImageMeta, k::AbstractString, default) = get(img.properties, k, de
 macro get(img, k, default)
     quote
         img, k = $(esc(img)), $(esc(k))
-        index = Base.ht_keyindex(img.properties, k)
-        (index > 0) ? img.properties.vals[index] : $(esc(default))
+        if isa(img.properties, Dict)
+            index = Base.ht_keyindex(img.properties, k)
+            (index > 0) ? img.properties.vals[index] : $(esc(default))
+        else
+            haskey(img.properties, k) ? img.properties[k] : $(esc(default))
+        end
     end
 end
 
@@ -350,7 +354,7 @@ function check_empty_spatialproperties(img)
 end
 
 #### Low-level utilities ####
-function showdictlines(io::IO, dict::Dict, suppress::Set)
+function showdictlines(io::IO, dict::AbstractDict, suppress::Set)
     for (k, v) in dict
         if k == "suppress"
             continue
@@ -363,7 +367,7 @@ function showdictlines(io::IO, dict::Dict, suppress::Set)
         end
     end
 end
-showdictlines(io::IO, dict::Dict, prop::String) = showdictlines(io, dict, Set([prop]))
+showdictlines(io::IO, dict::AbstractDict, prop::String) = showdictlines(io, dict, Set([prop]))
 
 # printdictval(io::IO, v) = print(io, v)
 # function printdictval(io::IO, v::Vector)

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -32,15 +32,15 @@ export
 Construct an image with `ImageMeta(A, props)` (for a properties dictionary
 `props`), or with `ImageMeta(A, prop1=val1, prop2=val2, ...)`.
 """
-mutable struct ImageMeta{T,N,A<:AbstractArray} <: AbstractArray{T,N}
+mutable struct ImageMeta{T,N,A<:AbstractArray,P<:AbstractDict{String,Any}} <: AbstractArray{T,N}
     data::A
-    properties::Dict{String,Any}
+    properties::P
 
-    function ImageMeta{T,N,A}(data::AbstractArray, properties::Dict) where {T,N,A}
-        new{T,N,A}(data, properties)
+    function ImageMeta{T,N,A,P}(data::AbstractArray, properties::P) where {T,N,A,P}
+        new{T,N,A,P}(data, properties)
     end
 end
-ImageMeta(data::AbstractArray{T,N}, props::Dict) where {T,N} = ImageMeta{T,N,typeof(data)}(data,props)
+ImageMeta(data::AbstractArray{T,N}, props::AbstractDict{String,Any}) where {T,N} = ImageMeta{T,N,typeof(data),typeof(props)}(data,props)
 ImageMeta(data::AbstractArray; kwargs...) = ImageMeta(data, kwargs2dict(kwargs))
 
 const ImageMetaArray{T,N,A<:Array} = ImageMeta{T,N,A}
@@ -48,7 +48,7 @@ const ImageMetaAxis{T,N,A<:AxisArray} = ImageMeta{T,N,A}
 
 Base.size(A::ImageMeta) = size(A.data)
 
-datatype(::Type{ImageMeta{T,N,A}}) where {T,N,A<:AbstractArray} = A
+datatype(::Type{ImageMeta{T,N,A,P}}) where {T,N,A<:AbstractArray,P} = A
 
 Base.IndexStyle(::Type{M}) where {M<:ImageMeta} = IndexStyle(datatype(M))
 

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -239,17 +239,6 @@ macro get(img, k, default)
         return isa(val, IMNothing) ? $(esc(default)) : val
     end
 end
-#macro get(img, k, default)
-#    quote
-#        img, k = $(esc(img)), $(esc(k))
-#        if isa(img.properties, Dict)
-#            index = Base.ht_keyindex(img.properties, k)
-#            (index > 0) ? img.properties.vals[index] : $(esc(default))
-#        else
-#            haskey(img.properties, k) ? img.properties[k] : $(esc(default))
-#        end
-#    end
-#end
 
 ImageAxes.timeaxis(img::ImageMetaAxis) = timeaxis(data(img))
 ImageAxes.timedim(img::ImageMetaAxis) = timedim(data(img))

--- a/test/core.jl
+++ b/test/core.jl
@@ -368,4 +368,13 @@ end
     @test mean(img,dims=1) == reshape([1.5,3.5], 1,2)
 end
 
+@testset "AbstractDicts" begin
+    img = ImageMeta(AxisArray(rand(3,5,8),
+                              Axis{:x}(1:3),
+                              Axis{:y}(1:5),
+                              Axis{:time}(0.1:0.1:0.8)),
+                    IdDict{String,Any}("pixelspacing" => (1,1)))
+    @test @inferred(pixelspacing(img)) === (1,1)
+end
+
 nothing


### PR DESCRIPTION
This relaxes the field requirements from `ImageMeta.properties <: Dict{String,Any}` to `ImageMeta.properties<:AbstractDict{String,Any}`.