### PR TITLE
Changes to make ImageMeta constructor work

### DIFF
--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -32,7 +32,7 @@ export
 Construct an image with `ImageMeta(A, props)` (for a properties dictionary
 `props`), or with `ImageMeta(A, prop1=val1, prop2=val2, ...)`.
 """
-mutable struct ImageMeta{T,N,A<:AbstractArray,P<:AbstractDict{String}} <: AbstractArray{T,N}
+mutable struct ImageMeta{T,N,A<:AbstractArray,P<:AbstractDict{String,Any}} <: AbstractArray{T,N}
     data::A
     properties::P
 
@@ -40,8 +40,10 @@ mutable struct ImageMeta{T,N,A<:AbstractArray,P<:AbstractDict{String}} <: Abstra
         new{T,N,A,P}(data, properties)
     end
 end
-ImageMeta(data::AbstractArray{T,N}, props::AbstractDict{S}) where {T,N,S<:AbstractString} = ImageMeta{T,N,typeof(data),typeof(props)}(data,props)
+ImageMeta(data::AbstractArray{T,N}, props::AbstractDict{String,Any}) where {T,N} = ImageMeta{T,N,typeof(data),typeof(props)}(data,props)
+ImageMeta(data::AbstractArray, props::AbstractDict{<:AbstractString}) = ImageMeta(data, convert(Dict{String,Any}, props))
 ImageMeta(data::AbstractArray; kwargs...) = ImageMeta(data, kwargs2dict(kwargs))
+ImageMeta(data::AbstractArray, props::AbstractDict) = throw(ArgumentError("properties must be an AbstractDict{String,Any}"))
 
 const ImageMetaArray{T,N,A<:Array} = ImageMeta{T,N,A}
 const ImageMetaAxis{T,N,A<:AxisArray} = ImageMeta{T,N,A}

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -41,7 +41,8 @@ mutable struct ImageMeta{T,N,A<:AbstractArray,P<:AbstractDict{String,Any}} <: Ab
     end
 end
 ImageMeta(data::AbstractArray{T,N}, props::AbstractDict{String,Any}) where {T,N} = ImageMeta{T,N,typeof(data),typeof(props)}(data,props)
-ImageMeta(data::AbstractArray, props::AbstractDict{<:AbstractString}) = ImageMeta(data, convert(Dict{String,Any}, props))
+ImageMeta(data::AbstractArray{T,N}, props::Dict{String,Any}) where {T,N} = ImageMeta{T,N,typeof(data),typeof(props)}(data,props)
+ImageMeta(data::AbstractArray, props::Dict{<:AbstractString}) = ImageMeta(data, convert(Dict{String,Any}, props))
 ImageMeta(data::AbstractArray; kwargs...) = ImageMeta(data, kwargs2dict(kwargs))
 ImageMeta(data::AbstractArray, props::AbstractDict) = throw(ArgumentError("properties must be an AbstractDict{String,Any}"))
 

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -32,7 +32,7 @@ export
 Construct an image with `ImageMeta(A, props)` (for a properties dictionary
 `props`), or with `ImageMeta(A, prop1=val1, prop2=val2, ...)`.
 """
-mutable struct ImageMeta{T,N,A<:AbstractArray,P<:AbstractDict{String,Any}} <: AbstractArray{T,N}
+mutable struct ImageMeta{T,N,A<:AbstractArray,P<:AbstractDict{String}} <: AbstractArray{T,N}
     data::A
     properties::P
 
@@ -40,7 +40,7 @@ mutable struct ImageMeta{T,N,A<:AbstractArray,P<:AbstractDict{String,Any}} <: Ab
         new{T,N,A,P}(data, properties)
     end
 end
-ImageMeta(data::AbstractArray{T,N}, props::AbstractDict{String,Any}) where {T,N} = ImageMeta{T,N,typeof(data),typeof(props)}(data,props)
+ImageMeta(data::AbstractArray{T,N}, props::AbstractDict{S}) where {T,N,S<:AbstractString} = ImageMeta{T,N,typeof(data),typeof(props)}(data,props)
 ImageMeta(data::AbstractArray; kwargs...) = ImageMeta(data, kwargs2dict(kwargs))
 
 const ImageMetaArray{T,N,A<:Array} = ImageMeta{T,N,A}

--- a/test/core.jl
+++ b/test/core.jl
@@ -375,6 +375,10 @@ end
                               Axis{:time}(0.1:0.1:0.8)),
                     IdDict{String,Any}("pixelspacing" => (1,1)))
     @test @inferred(pixelspacing(img)) === (1,1)
+
+    rand_img = rand(10,10)
+    dict = Dict("attr1" => 3, "attr2" => 4)
+    @test ImageMeta(rand_img, dict)[1, 1] == rand_img[1, 1]
 end
 
 nothing


### PR DESCRIPTION
Unsure on restrictions on metadata keys. Any comments? I don't like that there is a "String" requirement.