### PR TITLE
Defer to parent for `axes`

### DIFF
--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -47,6 +47,7 @@ const ImageMetaArray{T,N,A<:Array} = ImageMeta{T,N,A}
 const ImageMetaAxis{T,N,A<:AxisArray} = ImageMeta{T,N,A}
 
 Base.size(A::ImageMeta) = size(A.data)
+Base.axes(A::ImageMeta) = axes(A.data)
 
 datatype(::Type{ImageMeta{T,N,A,P}}) where {T,N,A<:AbstractArray,P} = A
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 SimpleTraits
 Unitful
+OffsetArrays

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,7 +1,9 @@
-using FixedPointNumbers, Colors, ColorVectorSpace, SimpleTraits, ImageAxes, ImageMetadata, AxisArrays
+using FixedPointNumbers, Colors, ColorVectorSpace, SimpleTraits, ImageAxes, ImageMetadata, OffsetArrays
 using Test
 import Dates: now
 using Unitful: m
+import AxisArrays
+using AxisArrays: AxisArray, axisnames, (..)
 
 @testset "indexing" begin
     # 1d images
@@ -112,6 +114,11 @@ using Unitful: m
     Broi = view(B, 2:3, 2:3)
     @test isa(Broi, ImageMeta)
     @test axisnames(Broi) == (:y, :x)
+
+    # Non-1 indexing
+    Ao = OffsetArray(rand(2,3), 0:1, -1:1)
+    A = ImageMeta(Ao, info="blah")
+    @test axes(A) === axes(Ao)
 end
 
 @testset "convert" begin


### PR DESCRIPTION
This also avoids breaking `axes` by importing, rather than using, AxisArrays in the tests.