### PR TITLE
add Project.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,11 @@ matrix:
 notifications:
   email: false
 
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("ImageMetadata")'
-  - julia --check-bounds=yes --color=yes -e 'import Pkg; Pkg.test("ImageMetadata"; coverage=true)'
+# use default script for julia
+# script:
+#   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#   - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("ImageMetadata")'
+#   - julia --check-bounds=yes --color=yes -e 'import Pkg; Pkg.test("ImageMetadata"; coverage=true)'
 
 after_success:
   # push coverage results to Codecov

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,27 @@
+name = "ImageMetadata"
+uuid = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
+version = "0.7.0"
+
+[deps]
+AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+ImageAxes = "2803e5a7-5153-5ecf-9a86-9b4c37f5f5ac"
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
+
+[compat]
+AxisArrays = ">= 0.3"
+ColorVectorSpace = ">= 0.1.11"
+FixedPointNumbers = ">= 0.3.0"
+ImageCore = ">= 0.7"
+julia = ">= 0.7"
+
+[extras]
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[targets]
+test = ["OffsetArrays", "SimpleTraits", "Unitful"]


### PR DESCRIPTION
a minor version bump is needed after this PR.

I change the `.travis.yml` so that it reads `Project.toml` (if I understand it right), if this change is unnecessary I can roll it back.

related PR: https://github.com/JuliaIO/QuartzImageIO.jl/pull/56