### PR TITLE
add ability to check size using Axis name

### DIFF
--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -50,6 +50,8 @@ const ImageMetaArray{T,N,A<:Array} = ImageMeta{T,N,A}
 const ImageMetaAxis{T,N,A<:AxisArray} = ImageMeta{T,N,A}
 
 Base.size(A::ImageMeta) = size(A.data)
+Base.size(A::ImageMetaAxis, Ax::Axis) = size(A.data, axisdim(A, Ax))
+Base.size(A::ImageMetaAxis, ::Type{Ax}) where {Ax<:Axis} = size(A.data, axisdim(A, Ax))
 Base.axes(A::ImageMeta) = axes(A.data)
 
 datatype(::Type{ImageMeta{T,N,A,P}}) where {T,N,A<:AbstractArray,P} = A

--- a/test/core.jl
+++ b/test/core.jl
@@ -274,6 +274,8 @@ end
     @test AxisArrays.HasAxes(M) == AxisArrays.HasAxes{true}()
     @test AxisArrays.axes(M) == (Axis{:y}(1:3), Axis{:x}(1:5))
     @test axisdim(M, Axis{:y}) == 1
+    @test size(M, Axis{:y}) == 3
+    @test size(M, Axis{:x}()) == 5
     @test axisdim(M, Axis{:x}) == 2
     @test_throws ErrorException axisdim(M, Axis{:z})
     @test axisnames(M) == (:y, :x)


### PR DESCRIPTION
AxisArrays have the nifty ability to check the size of a dimension without knowing its index by passing the name of the axis to `size`. This PR adds this ability to `ImageMetas`.

@timholy 