### PR TITLE
add support for more AxisArrays.axes definitions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,10 @@ julia = "0.7, 1"
 [extras]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [targets]
-test = ["OffsetArrays", "SimpleTraits", "Unitful"]
+test = ["Test", "Statistics", "Dates", "OffsetArrays", "SimpleTraits", "Unitful"]

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -218,6 +218,8 @@ ImageCore.normedview(::Type{T}, A::ImageMeta{S}) where {T<:FixedPoint,S<:Unsigne
 # AxisArrays functions
 AxisArrays.axes(img::ImageMetaAxis) = AxisArrays.axes(img.data)
 AxisArrays.axes(img::ImageMetaAxis, d::Int) = AxisArrays.axes(img.data, d)
+AxisArrays.axes(img::ImageMetaAxis, Ax::Axis) = AxisArrays.axes(img.data, Ax)
+AxisArrays.axes(img::ImageMetaAxis, ::Type{Ax}) where {Ax<:Axis} = AxisArrays.axes(img.data, Ax)
 AxisArrays.axisdim(img::ImageMetaAxis, ax) = axisdim(img.data, ax)
 AxisArrays.axisnames(img::ImageMetaAxis) = axisnames(img.data)
 AxisArrays.axisvalues(img::ImageMetaAxis) = axisvalues(img.data)

--- a/test/core.jl
+++ b/test/core.jl
@@ -274,6 +274,8 @@ end
     @test AxisArrays.HasAxes(M) == AxisArrays.HasAxes{true}()
     @test AxisArrays.axes(M) == (Axis{:y}(1:3), Axis{:x}(1:5))
     @test AxisArrays.axes(M, 2) == Axis{:x}(1:5)
+    @test AxisArrays.axes(M, Axis{:y}) == Axis{:y}(1:3)
+    @test AxisArrays.axes(M, Axis{:x}()) == Axis{:x}(1:5)
     @test axisdim(M, Axis{:y}) == 1
     @test size(M, Axis{:y}) == 3
     @test size(M, Axis{:x}()) == 5


### PR DESCRIPTION
This adds support for the following `AxisArrays.axes` definitions, which should make working with `ImageMetadata` objects less clunky.

```
[7] axes(img::ImageMeta{T,N,A,P} where A<:AxisArray, Ax::Axis)
[8] axes(img::ImageMeta{T,N,A,P} where A<:AxisArray, ::Type{Ax}) where Ax<:Axis
```