### PR TITLE
Switch to `Symbol` keys

### DIFF
--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -132,7 +132,7 @@ Base.view(img::ImageMeta, I::Vararg{ViewIndex,N}) where {N} = shareproperties(im
 function Base.getproperty(img::ImageMeta, propname::Symbol)
     # TODO remove these once deprecations are done
     if propname === :data
-        Base.depwarn("img.data is deprecated use arraydata(img) to extract data img.", :data)
+        Base.depwarn("img.data is deprecated use arraydata(img) to extract data img.", :arraydata)
         return arraydata(img)
     elseif propname === :properties
         Base.depwarn("img.properties is deprecated use properties(img) to extract data img.", :properties)
@@ -142,8 +142,20 @@ function Base.getproperty(img::ImageMeta, propname::Symbol)
     end
 end
 
-function Base.setproperty!(img::ImageMeta, propname::Symbol, X)
-    return setindex!(properties(img), X, propname)
+function Base.setproperty!(img::ImageMeta, propname::Symbol, val)
+    # TODO remove these once deprecations are done
+    if propname === :data
+        Base.depwarn("Replacing the data field with is deprecated. Consider creating a new instance of ImageMeta instead.", :rawdata)
+        setindex!(img, val, img)
+    elseif propname === :properties
+        Base.depwarn("Replacing the properties field is deprecated. Consider creating a new instance of ImageMeta instead.", :properties)
+        for (k,v) in val
+            setproperty!(img, k, v)
+        end
+    else
+        properties(img)[propname] = val
+    end
+    return img
 end
 
 Base.propertynames(img::ImageMeta) = (keys(properties(img))...,)

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -21,7 +21,9 @@ export
     data,
     properties,
     shareproperties,
-    spatialproperties
+    spatialproperties,
+    # export for < v"1.2"
+    hasproperty
 
 #### types and constructors ####
 
@@ -259,7 +261,13 @@ See also: [`data`](@ref).
 """
 properties(img::ImageMeta) = getfield(img, :properties)
 
-Base.hasproperty(img::ImageMeta, k::Symbol) = haskey(properties(img), k)
+
+if isdefined(Base, :hasproperty) # or VERSION >= v"1.2"
+    import Base: hasproperty
+    Base.hasproperty(img::ImageMeta, k::Symbol) = haskey(properties(img), k)
+else
+    hasproperty(img::ImageMeta, k::Symbol) = haskey(properties(img), k)
+end
 
 Base.get(img::ImageMeta, k::Symbol, default) = get(properties(img), k, default)
 
@@ -415,6 +423,7 @@ function kwargs2dict(kwargs)
     end
     return d
 end
+
 
 include("operators.jl")
 include("deprecations.jl")

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -19,7 +19,7 @@ export
 
     # functions
     copyproperties,
-    data,
+    arraydata,
     properties,
     shareproperties,
     spatialproperties
@@ -59,12 +59,12 @@ ImageMeta(data::AbstractArray, props::AbstractDict) = throw(ArgumentError("prope
 const ImageMetaArray{T,N,A<:Array} = ImageMeta{T,N,A}
 const ImageMetaAxis{T,N,A<:AxisArray} = ImageMeta{T,N,A}
 
-Base.size(A::ImageMeta) = size(data(A))
-Base.size(A::ImageMetaAxis, Ax::Axis) = size(data(A), Ax)
-Base.size(A::ImageMetaAxis, ::Type{Ax}) where {Ax<:Axis} = size(data(A), Ax)
-Base.axes(A::ImageMeta) = axes(data(A))
-Base.axes(A::ImageMetaAxis, Ax::Axis) = axes(data(A), Ax)
-Base.axes(A::ImageMetaAxis, ::Type{Ax}) where {Ax<:Axis} = axes(data(A), Ax)
+Base.size(A::ImageMeta) = size(arraydata(A))
+Base.size(A::ImageMetaAxis, Ax::Axis) = size(arraydata(A), Ax)
+Base.size(A::ImageMetaAxis, ::Type{Ax}) where {Ax<:Axis} = size(arraydata(A), Ax)
+Base.axes(A::ImageMeta) = axes(arraydata(A))
+Base.axes(A::ImageMetaAxis, Ax::Axis) = axes(arraydata(A), Ax)
+Base.axes(A::ImageMetaAxis, ::Type{Ax}) where {Ax<:Axis} = axes(arraydata(A), Ax)
 
 datatype(::Type{ImageMeta{T,N,A,P}}) where {T,N,A<:AbstractArray,P} = A
 
@@ -76,45 +76,45 @@ AxisArrays.HasAxes(A::ImageMetaAxis) = AxisArrays.HasAxes{true}()
 for AType in (ImageMeta, ImageMetaAxis)
     @eval begin
         @inline function Base.getindex(img::$AType{T,1}, i::Int) where T
-            @boundscheck checkbounds(data(img), i)
-            @inbounds ret = data(img)[i]
+            @boundscheck checkbounds(arraydata(img), i)
+            @inbounds ret = arraydata(img)[i]
             ret
         end
         @inline function Base.getindex(img::$AType, i::Int)
-            @boundscheck checkbounds(data(img), i)
-            @inbounds ret = data(img)[i]
+            @boundscheck checkbounds(arraydata(img), i)
+            @inbounds ret = arraydata(img)[i]
             ret
         end
         @inline function Base.getindex(img::$AType{T,N}, I::Vararg{Int,N}) where {T,N}
-            @boundscheck checkbounds(data(img), I...)
-            @inbounds ret = data(img)[I...]
+            @boundscheck checkbounds(arraydata(img), I...)
+            @inbounds ret = arraydata(img)[I...]
             ret
         end
 
         @inline function Base.setindex!(img::$AType{T,1}, val, i::Int) where T
-            @boundscheck checkbounds(data(img), i)
-            @inbounds data(img)[i] = val
+            @boundscheck checkbounds(arraydata(img), i)
+            @inbounds arraydata(img)[i] = val
             val
         end
         @inline function Base.setindex!(img::$AType, val, i::Int)
-            @boundscheck checkbounds(data(img), i)
-            @inbounds data(img)[i] = val
+            @boundscheck checkbounds(arraydata(img), i)
+            @inbounds arraydata(img)[i] = val
             val
         end
         @inline function Base.setindex!(img::$AType{T,N}, val, I::Vararg{Int,N}) where {T,N}
-            @boundscheck checkbounds(data(img), I...)
-            @inbounds data(img)[I...] = val
+            @boundscheck checkbounds(arraydata(img), I...)
+            @inbounds arraydata(img)[I...] = val
             val
         end
     end
 end
 
 @inline function Base.getindex(img::ImageMetaAxis, ax::Axis, I...)
-    result = data(img)[ax, I...]
+    result = arraydata(img)[ax, I...]
     maybe_wrap(img, result)
 end
 @inline function Base.getindex(img::ImageMetaAxis, i::Union{Integer,AbstractVector,Colon}, I...)
-    result = data(img)[i, I...]
+    result = arraydata(img)[i, I...]
     maybe_wrap(img, result)
 end
 maybe_wrap(img::ImageMeta{T}, result::T) where T = result
@@ -122,22 +122,22 @@ maybe_wrap(img::ImageMeta{T}, result::AbstractArray{T}) where T = copyproperties
 
 
 @inline function Base.setindex!(img::ImageMetaAxis, val, ax::Axis, I...)
-    setindex!(data(img), val, ax, I...)
+    setindex!(arraydata(img), val, ax, I...)
 end
 @inline function Base.setindex!(img::ImageMetaAxis, val, i::Union{Integer,AbstractVector,Colon}, I...)
-    setindex!(data(img), val, i, I...)
+    setindex!(arraydata(img), val, i, I...)
 end
 
-Base.view(img::ImageMeta, ax::Axis, I...) = shareproperties(img, view(data(img), ax, I...))
-Base.view(img::ImageMeta{T,N}, I::Vararg{ViewIndex,N}) where {T,N} = shareproperties(img, view(data(img), I...))
-Base.view(img::ImageMeta, i::ViewIndex) = shareproperties(img, view(data(img), i))
-Base.view(img::ImageMeta, I::Vararg{ViewIndex,N}) where {N} = shareproperties(img, view(data(img), I...))
+Base.view(img::ImageMeta, ax::Axis, I...) = shareproperties(img, view(arraydata(img), ax, I...))
+Base.view(img::ImageMeta{T,N}, I::Vararg{ViewIndex,N}) where {T,N} = shareproperties(img, view(arraydata(img), I...))
+Base.view(img::ImageMeta, i::ViewIndex) = shareproperties(img, view(arraydata(img), i))
+Base.view(img::ImageMeta, I::Vararg{ViewIndex,N}) where {N} = shareproperties(img, view(arraydata(img), I...))
 
 function Base.getproperty(img::ImageMeta, propname::Symbol)
     # TODO remove these once deprecations are done
     if propname === :data
-        Base.depwarn("img.data is deprecated use data(img) to extract data img.", :data)
-        return data(img)
+        Base.depwarn("img.data is deprecated use arraydata(img) to extract data img.", :data)
+        return arraydata(img)
     elseif propname === :properties
         Base.depwarn("img.properties is deprecated use properties(img) to extract data img.", :properties)
         return properties(img)
@@ -152,12 +152,12 @@ end
 
 Base.propertynames(img::ImageMeta) = (keys(properties(img))...,)
 
-Base.copy(img::ImageMeta) = ImageMeta(copy(data(img)), deepcopy(properties(img)))
+Base.copy(img::ImageMeta) = ImageMeta(copy(arraydata(img)), deepcopy(properties(img)))
 
 Base.convert(::Type{ImageMeta}, A::ImageMeta) = A
 Base.convert(::Type{ImageMeta}, A::AbstractArray) = ImageMeta(A)
 Base.convert(::Type{ImageMeta{T}}, A::ImageMeta{T}) where {T} = A
-Base.convert(::Type{ImageMeta{T}}, A::ImageMeta) where {T} = shareproperties(A, convert(Array{T}, data(A)))
+Base.convert(::Type{ImageMeta{T}}, A::ImageMeta) where {T} = shareproperties(A, convert(Array{T}, arraydata(A)))
 Base.convert(::Type{ImageMeta{T}}, A::AbstractArray) where {T} = ImageMeta(convert(Array{T}, A))
 
 # copy properties
@@ -170,8 +170,8 @@ function Base.copy!(imgdest::ImageMeta, imgsrc::ImageMeta, prop1::Symbol, props:
 end
 
 # similar
-Base.similar(img::ImageMeta, ::Type{T}, shape::Dims) where {T} = ImageMeta(similar(data(img), T, shape), copy(properties(img)))
-Base.similar(img::ImageMetaAxis, ::Type{T}) where {T} = ImageMeta(similar(data(img), T), copy(properties(img)))
+Base.similar(img::ImageMeta, ::Type{T}, shape::Dims) where {T} = ImageMeta(similar(arraydata(img), T, shape), copy(properties(img)))
+Base.similar(img::ImageMetaAxis, ::Type{T}) where {T} = ImageMeta(similar(arraydata(img), T), copy(properties(img)))
 
 """
     copyproperties(img::ImageMeta, data) -> imgnew
@@ -202,26 +202,26 @@ Base.delete!(img::ImageMeta, propname::Symbol) = delete!(properties(img), propna
 
 # Iteration
 # Defer to the array object in case it has special iteration defined
-Base.iterate(img::ImageMeta) = Base.iterate(data(img))
-Base.iterate(img::ImageMeta, s) = Base.iterate(data(img), s)
+Base.iterate(img::ImageMeta) = Base.iterate(arraydata(img))
+Base.iterate(img::ImageMeta, s) = Base.iterate(arraydata(img), s)
 
 # Show
 const emptyset = Set()
 function showim(io::IO, img::ImageMeta)
     IT = typeof(img)
-    print(io, eltype(img).name.name, " ImageMeta with:\n  data: ", summary(data(img)), "\n  properties:")
+    print(io, eltype(img).name.name, " ImageMeta with:\n  data: ", summary(arraydata(img)), "\n  properties:")
     showdictlines(io, properties(img), get(img, :suppress, emptyset))
 end
 Base.show(io::IO, img::ImageMeta) = showim(io, img)
 Base.show(io::IO, ::MIME"text/plain", img::ImageMeta) = showim(io, img)
 
 function Base.reinterpret(::Type{T}, img::ImageMeta) where {T}
-    shareproperties(img, reinterpret(T, data(img)))
+    shareproperties(img, reinterpret(T, arraydata(img)))
 end
 
 
 """
-    data(img::ImageMeta) -> array
+    arraydata(img::ImageMeta) -> array
 
 Extract the data from `img`, omitting the properties
 dictionary. `array` shares storage with `img`, so changes to one
@@ -229,26 +229,26 @@ affect the other.
 
 See also: [`properties`](@ref).
 """
-ImageAxes.data(img::ImageMeta) = getfield(img, :data)  # fixme when deprecation is removed from ImageCore
+ImageAxes.arraydata(img::ImageMeta) = getfield(img, :data)
 
 function ImageCore.permuteddimsview(A::ImageMeta, perm)
     ip = sortperm([perm...][[coords_spatial(A)...]])  # the inverse spatial permutation
-    permutedims_props!(copyproperties(A, permuteddimsview(data(A), perm)), ip)
+    permutedims_props!(copyproperties(A, permuteddimsview(arraydata(A), perm)), ip)
 end
-ImageCore.channelview(A::ImageMeta) = shareproperties(A, channelview(data(A)))
-ImageCore.colorview(::Type{C}, A::ImageMeta{T,N}) where {C<:Colorant,T,N} = shareproperties(A, colorview(C, data(A)))
-ImageCore.colorview(::Type{ARGB32}, A::ImageMeta{T,N}) where {T,N} = shareproperties(A, colorview(ARGB32, data(A)))
-ImageCore.rawview(A::ImageMeta{T}) where {T<:Real} = shareproperties(A, rawview(data(A)))
-ImageCore.normedview(::Type{T}, A::ImageMeta{S}) where {T<:FixedPoint,S<:Unsigned} = shareproperties(A, normedview(T, data(A)))
+ImageCore.channelview(A::ImageMeta) = shareproperties(A, channelview(arraydata(A)))
+ImageCore.colorview(::Type{C}, A::ImageMeta{T,N}) where {C<:Colorant,T,N} = shareproperties(A, colorview(C, arraydata(A)))
+ImageCore.colorview(::Type{ARGB32}, A::ImageMeta{T,N}) where {T,N} = shareproperties(A, colorview(ARGB32, arraydata(A)))
+ImageCore.rawview(A::ImageMeta{T}) where {T<:Real} = shareproperties(A, rawview(arraydata(A)))
+ImageCore.normedview(::Type{T}, A::ImageMeta{S}) where {T<:FixedPoint,S<:Unsigned} = shareproperties(A, normedview(T, arraydata(A)))
 
 # AxisArrays functions
-AxisArrays.axes(img::ImageMetaAxis) = AxisArrays.axes(data(img))
-AxisArrays.axes(img::ImageMetaAxis, d::Int) = AxisArrays.axes(data(img), d)
-AxisArrays.axes(img::ImageMetaAxis, Ax::Axis) = AxisArrays.axes(data(img), Ax)
-AxisArrays.axes(img::ImageMetaAxis, ::Type{Ax}) where {Ax<:Axis} = AxisArrays.axes(data(img), Ax)
-AxisArrays.axisdim(img::ImageMetaAxis, ax) = axisdim(data(img), ax)
-AxisArrays.axisnames(img::ImageMetaAxis) = axisnames(data(img))
-AxisArrays.axisvalues(img::ImageMetaAxis) = axisvalues(data(img))
+AxisArrays.axes(img::ImageMetaAxis) = AxisArrays.axes(arraydata(img))
+AxisArrays.axes(img::ImageMetaAxis, d::Int) = AxisArrays.axes(arraydata(img), d)
+AxisArrays.axes(img::ImageMetaAxis, Ax::Axis) = AxisArrays.axes(arraydata(img), Ax)
+AxisArrays.axes(img::ImageMetaAxis, ::Type{Ax}) where {Ax<:Axis} = AxisArrays.axes(arraydata(img), Ax)
+AxisArrays.axisdim(img::ImageMetaAxis, ax) = axisdim(arraydata(img), ax)
+AxisArrays.axisnames(img::ImageMetaAxis) = axisnames(arraydata(img))
+AxisArrays.axisvalues(img::ImageMetaAxis) = axisvalues(arraydata(img))
 
 #### Properties ####
 
@@ -281,11 +281,11 @@ macro get(img, k, default)
     end
 end
 
-ImageAxes.timeaxis(img::ImageMetaAxis) = timeaxis(data(img))
-ImageAxes.timedim(img::ImageMetaAxis) = timedim(data(img))
-ImageAxes.colordim(img::ImageMetaAxis) = colordim(data(img))
+ImageAxes.timeaxis(img::ImageMetaAxis) = timeaxis(arraydata(img))
+ImageAxes.timedim(img::ImageMetaAxis) = timedim(arraydata(img))
+ImageAxes.colordim(img::ImageMetaAxis) = colordim(arraydata(img))
 
-ImageCore.pixelspacing(img::ImageMeta) = pixelspacing(data(img))
+ImageCore.pixelspacing(img::ImageMeta) = pixelspacing(arraydata(img))
 
 """
     spacedirections(img)
@@ -302,21 +302,21 @@ If not specified, it will be computed from `pixelspacing(img)`, placing the
 spacing along the "diagonal".  If desired, you can set this property in terms of
 physical units, and each axis can have distinct units.
 """
-ImageCore.spacedirections(img::ImageMeta) = @get img :spacedirections spacedirections(data(img))
+ImageCore.spacedirections(img::ImageMeta) = @get img :spacedirections spacedirections(arraydata(img))
 
-ImageCore.sdims(img::ImageMetaAxis) = sdims(data(img))
+ImageCore.sdims(img::ImageMetaAxis) = sdims(arraydata(img))
 
-ImageCore.coords_spatial(img::ImageMetaAxis) = coords_spatial(data(img))
+ImageCore.coords_spatial(img::ImageMetaAxis) = coords_spatial(arraydata(img))
 
-ImageCore.spatialorder(img::ImageMetaAxis) = spatialorder(data(img))
+ImageCore.spatialorder(img::ImageMetaAxis) = spatialorder(arraydata(img))
 
-ImageAxes.nimages(img::ImageMetaAxis) = nimages(data(img))
+ImageAxes.nimages(img::ImageMetaAxis) = nimages(arraydata(img))
 
-ImageCore.size_spatial(img::ImageMetaAxis) = size_spatial(data(img))
+ImageCore.size_spatial(img::ImageMetaAxis) = size_spatial(arraydata(img))
 
-ImageCore.indices_spatial(img::ImageMetaAxis) = indices_spatial(data(img))
+ImageCore.indices_spatial(img::ImageMetaAxis) = indices_spatial(arraydata(img))
 
-ImageCore.assert_timedim_last(img::ImageMetaAxis) = assert_timedim_last(data(img))
+ImageCore.assert_timedim_last(img::ImageMetaAxis) = assert_timedim_last(arraydata(img))
 
 #### Permutations over dimensions ####
 
@@ -350,24 +350,24 @@ function permutedims_props!(ret::ImageMeta, ip, spatialprops=spatialproperties(r
 end
 
 function permutedims(img::ImageMetaAxis, perm)
-    p = AxisArrays.permutation(perm, axisnames(data(img)))
+    p = AxisArrays.permutation(perm, axisnames(arraydata(img)))
     ip = sortperm([p...][[coords_spatial(img)...]])
-    permutedims_props!(copyproperties(img, permutedims(data(img), p)), ip)
+    permutedims_props!(copyproperties(img, permutedims(arraydata(img), p)), ip)
 end
 function permutedims(img::ImageMeta, perm)
     ip = sortperm([perm...][[coords_spatial(img)...]])
-    permutedims_props!(copyproperties(img, permutedims(data(img), perm)), ip)
+    permutedims_props!(copyproperties(img, permutedims(arraydata(img), perm)), ip)
 end
 
 # Note: `adjoint` does not recurse into ImageMeta properties.
 function Base.adjoint(img::ImageMeta{T,2}) where {T<:Real}
     ip = sortperm([2,1][[coords_spatial(img)...]])
-    permutedims_props!(copyproperties(img, adjoint(data(img))), ip)
+    permutedims_props!(copyproperties(img, adjoint(arraydata(img))), ip)
 end
 
 function Base.adjoint(img::ImageMeta{T,1}) where T<:Real
     check_empty_spatialproperties(img)
-    copyproperties(img, data(img)')
+    copyproperties(img, arraydata(img)')
 end
 
 """

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -147,7 +147,7 @@ function Base.getproperty(img::ImageMeta, propname::Symbol)
 end
 
 function Base.setproperty!(img::ImageMeta, propname::Symbol, X)
-    return setindex!(properties(img), X, propname )
+    return setindex!(properties(img), X, propname)
 end
 
 Base.propertynames(img::ImageMeta) = (keys(properties(img))...,)
@@ -170,8 +170,8 @@ function Base.copy!(imgdest::ImageMeta, imgsrc::ImageMeta, prop1::Symbol, props:
 end
 
 # similar
-Base.similar(img::ImageMeta, ::Type{T}, shape::Dims) where {T} = ImageMeta(similar(data(img), T, shape), deepcopy(properties(img)))
-Base.similar(img::ImageMetaAxis, ::Type{T}) where {T} = ImageMeta(similar(data(img), T), deepcopy(properties(img)))
+Base.similar(img::ImageMeta, ::Type{T}, shape::Dims) where {T} = ImageMeta(similar(data(img), T, shape), copy(properties(img)))
+Base.similar(img::ImageMetaAxis, ::Type{T}) where {T} = ImageMeta(similar(data(img), T), copy(properties(img)))
 
 """
     copyproperties(img::ImageMeta, data) -> imgnew
@@ -183,7 +183,7 @@ properties of `imgnew` does not affect the properties of `img`.
 See also: [`shareproperties`](@ref).
 """
 copyproperties(img::ImageMeta, data::AbstractArray) =
-    ImageMeta(data, deepcopy(properties(img)))
+    ImageMeta(data, copy(properties(img)))
 
 """
     shareproperties(img::ImageMeta, data) -> imgnew

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -10,6 +10,7 @@ import AxisArrays
 import Base: +, -, *, /
 import Base: permutedims
 
+
 const ViewIndex = Union{Base.ViewIndex, Colon}
 
 export
@@ -21,9 +22,7 @@ export
     data,
     properties,
     shareproperties,
-    spatialproperties,
-    # export for < v"1.2"
-    hasproperty
+    spatialproperties
 
 #### types and constructors ####
 
@@ -137,9 +136,11 @@ Base.view(img::ImageMeta, I::Vararg{ViewIndex,N}) where {N} = shareproperties(im
 function Base.getproperty(img::ImageMeta, propname::Symbol)
     # TODO remove these once deprecations are done
     if propname === :data
-        return getproperty_data(img)
+        Base.depwarn("img.data is deprecated use data(img) to extract data img.", :data)
+        return data(img)
     elseif propname === :properties
-        return getproperty_properties(img)
+        Base.depwarn("img.properties is deprecated use properties(img) to extract data img.", :properties)
+        return properties(img)
     else
         return properties(img)[propname]
     end
@@ -264,10 +265,8 @@ properties(img::ImageMeta) = getfield(img, :properties)
 
 if isdefined(Base, :hasproperty) # or VERSION >= v"1.2"
     import Base: hasproperty
-    Base.hasproperty(img::ImageMeta, k::Symbol) = haskey(properties(img), k)
-else
-    hasproperty(img::ImageMeta, k::Symbol) = haskey(properties(img), k)
 end
+hasproperty(img::ImageMeta, k::Symbol) = haskey(properties(img), k)
 
 Base.get(img::ImageMeta, k::Symbol, default) = get(properties(img), k, default)
 

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -33,7 +33,7 @@ export
 Construct an image with `ImageMeta(A, props)` (for a properties dictionary
 `props`), or with `ImageMeta(A, prop1=val1, prop2=val2, ...)`.
 """
-mutable struct ImageMeta{T,N,A<:AbstractArray,P<:AbstractDict{Symbol,Any}} <: AbstractArray{T,N}
+struct ImageMeta{T,N,A<:AbstractArray,P<:AbstractDict{Symbol,Any}} <: AbstractArray{T,N}
     data::A
     properties::P
 

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -133,7 +133,14 @@ Base.view(img::ImageMeta, i::ViewIndex) = shareproperties(img, view(data(img), i
 Base.view(img::ImageMeta, I::Vararg{ViewIndex,N}) where {N} = shareproperties(img, view(data(img), I...))
 
 function Base.getproperty(img::ImageMeta, propname::Symbol)
-    return properties(img)[propname]
+    # TODO remove these once deprecations are done
+    if propname === :data
+        return getproperty_data(img)
+    elseif propname === :properties
+        return getproperty_properties(img)
+    else
+        return properties(img)[propname]
+    end
 end
 
 function Base.setproperty!(img::ImageMeta, propname::Symbol, X)
@@ -319,13 +326,13 @@ function permutedims_props!(ret::ImageMeta, ip, spatialprops=spatialproperties(r
     if !isempty(spatialprops)
         for prop in spatialprops
             if hasproperty(ret, prop)
-                a = properties(ret)[prop]
+                a = getproperty(ret, prop)
                 if isa(a, AbstractVector)
-                    properties(ret)[prop] = a[ip]
+                    setproperty!(ret, prop, a[ip])
                 elseif isa(a, Tuple)
-                    properties(ret)[prop] = a[ip]
+                    setproperty!(ret, prop, a[ip])
                 elseif isa(a, AbstractMatrix) && size(a,1) == size(a,2)
-                    properties(ret)[prop] = a[ip,ip]
+                    setproperty!(ret, prop, a[ip,ip])
                 else
                     error("Do not know how to handle property ", prop)
                 end

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -254,8 +254,6 @@ properties(img::ImageMeta) = getfield(img, :properties)
 
 Base.hasproperty(img::ImageMeta, k::Symbol) = haskey(properties(img), k)
 
-# TODO do we want to keep this so there's an option for retrieving properties with
-# a default condition?
 Base.get(img::ImageMeta, k::Symbol, default) = get(properties(img), k, default)
 
 # So that defaults don't have to be evaluated unless they are needed,

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -36,10 +36,6 @@ Construct an image with `ImageMeta(A, props)` (for a properties dictionary
 struct ImageMeta{T,N,A<:AbstractArray,P<:AbstractDict{Symbol,Any}} <: AbstractArray{T,N}
     data::A
     properties::P
-
-    function ImageMeta{T,N,A,P}(data::AbstractArray, properties::P) where {T,N,A,P}
-        new{T,N,A,P}(data, properties)
-    end
 end
 
 function ImageMeta(data::AbstractArray{T,N}, props::AbstractDict{Symbol,Any}) where {T,N}

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,5 +1,5 @@
 # have to import this or @deprecate doesn't work
-import Base: getindex, setindex!, delete!, haskey, get, copy!, hasproperty, getproperty, setproperty!
+import Base: getindex, setindex!, delete!, haskey, get, copy!, getproperty, setproperty!
 
 @deprecate(ImageMeta(data::AbstractArray{T,N}, props::AbstractDict{String,Any}) where {T,N},
            ImageMeta(data, to_dict(props)))
@@ -48,5 +48,3 @@ function to_dict(dold::AbstractDict{String})
     end
     return dnew
 end
-
-

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -23,10 +23,16 @@ import Base: getindex, setindex!, delete!, haskey, get, copy!
            delete!(img, Symbol(propname)))
 
 @deprecate(haskey(img::ImageMeta, k::AbstractString),
-           haskey(img, Symbol(k)))
+           hasproperty(img, Symbol(k)))
 
 @deprecate(get(img::ImageMeta, k::AbstractString, default),
            get(img, k, Symbol(default)))
+
+@deprecate(getindex(img::ImageMeta, propname::Symbol),
+           getproperty(img, propname))
+
+@deprecate(setindex!(img::ImageMeta, X, propname::Symbol),
+           setproperty!(img, propname, X))
 
 function to_dict(dold::AbstractDict{String,Any})
     dnew = Dict{Symbol,Any}()
@@ -35,4 +41,5 @@ function to_dict(dold::AbstractDict{String,Any})
     end
     return dnew
 end
+
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -10,12 +10,6 @@ import Base: getindex, setindex!, delete!, haskey, get, copy!
 @deprecate(ImageMeta(data::AbstractArray, props::Dict{<:AbstractString}),
            ImageMeta(data, to_dict(props)))
 
-@deprecate(getindex(img::ImageMeta, propname::AbstractString),
-           getindex(img, Symbol(propname)))
-
-@deprecate(setindex!(img::ImageMeta, X, propname::AbstractString),
-           setindex!(img, X, Symbol(propname)))
-
 @deprecate(copy!(imgdest::ImageMeta, imgsrc::ImageMeta, prop1::AbstractString, props::AbstractString...),
            copy!(imgdest, imgsrc, Symbol(prop1), Symbol.(props)...))
 
@@ -26,7 +20,7 @@ import Base: getindex, setindex!, delete!, haskey, get, copy!
            hasproperty(img, Symbol(k)))
 
 @deprecate(get(img::ImageMeta, k::AbstractString, default),
-           get(img, k, Symbol(default)))
+           get(img, Symbol(k), default))
 
 @deprecate(getindex(img::ImageMeta, propname::Symbol),
            getproperty(img, propname))

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -37,10 +37,6 @@ import Base: getindex, setindex!, delete!, haskey, get, copy!, getproperty, setp
 @deprecate(setindex!(img::ImageMeta, X, propname::AbstractString),
            setproperty!(img, Symbol(propname), X))
 
-@deprecate(getproperty_data(img), data(img))
-
-@deprecate(getproperty_properties(img), properties(img))
-
 function to_dict(dold::AbstractDict{String})
     dnew = Dict{Symbol,Any}()
     for (k, v) in dold

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,5 +1,5 @@
 # have to import this or @deprecate doesn't work
-import Base: getindex, setindex!, delete!, haskey, get, copy!
+import Base: getindex, setindex!, delete!, haskey, get, copy!, hasproperty, getproperty, setproperty!
 
 @deprecate(ImageMeta(data::AbstractArray{T,N}, props::AbstractDict{String,Any}) where {T,N},
            ImageMeta(data, to_dict(props)))
@@ -19,16 +19,29 @@ import Base: getindex, setindex!, delete!, haskey, get, copy!
 @deprecate(haskey(img::ImageMeta, k::AbstractString),
            hasproperty(img, Symbol(k)))
 
+@deprecate(hasproperty(img::ImageMeta, k::AbstractString),
+           hasproperty(img, Symbol(k)))
+
 @deprecate(get(img::ImageMeta, k::AbstractString, default),
            get(img, Symbol(k), default))
 
-@deprecate(getindex(img::ImageMeta, propname::Symbol),
-           getproperty(img, propname))
+@deprecate(getindex(img::ImageMeta, propname::AbstractString),
+           getproperty(img, Symbol(propname)))
 
-@deprecate(setindex!(img::ImageMeta, X, propname::Symbol),
-           setproperty!(img, propname, X))
+@deprecate(getproperty(img::ImageMeta, propname::AbstractString),
+           getproperty(img, Symbol(propname)))
 
-function to_dict(dold::AbstractDict{String,Any})
+@deprecate(setproperty!(img::ImageMeta, propname::AbstractString, val),
+           setproperty!(img::ImageMeta, Symbol(propname), val))
+
+@deprecate(setindex!(img::ImageMeta, X, propname::AbstractString),
+           setproperty!(img, Symbol(propname), X))
+
+@deprecate(getproperty_data(img), data(img))
+
+@deprecate(getproperty_properties(img), properties(img))
+
+function to_dict(dold::AbstractDict{String})
     dnew = Dict{Symbol,Any}()
     for (k, v) in dold
         dnew[Symbol(k)] = v

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,38 @@
+# have to import this or @deprecate doesn't work
+import Base: getindex, setindex!, delete!, haskey, get, copy!
+
+@deprecate(ImageMeta(data::AbstractArray{T,N}, props::AbstractDict{String,Any}) where {T,N},
+           ImageMeta(data, to_dict(props)))
+
+@deprecate(ImageMeta(data::AbstractArray{T,N}, props::Dict{String,Any}) where {T,N},
+           ImageMeta(data, to_dict(props)))
+
+@deprecate(ImageMeta(data::AbstractArray, props::Dict{<:AbstractString}),
+           ImageMeta(data, to_dict(props)))
+
+@deprecate(getindex(img::ImageMeta, propname::AbstractString),
+           getindex(img, Symbol(propname)))
+
+@deprecate(setindex!(img::ImageMeta, X, propname::AbstractString),
+           setindex!(img, X, Symbol(propname)))
+
+@deprecate(copy!(imgdest::ImageMeta, imgsrc::ImageMeta, prop1::AbstractString, props::AbstractString...),
+           copy!(imgdest, imgsrc, Symbol(prop1), Symbol.(props)...))
+
+@deprecate(delete!(img::ImageMeta, propname::AbstractString),
+           delete!(img, Symbol(propname)))
+
+@deprecate(haskey(img::ImageMeta, k::AbstractString),
+           haskey(img, Symbol(k)))
+
+@deprecate(get(img::ImageMeta, k::AbstractString, default),
+           get(img, k, Symbol(default)))
+
+function to_dict(dold::AbstractDict{String,Any})
+    dnew = Dict{Symbol,Any}()
+    for (k, v) in dold
+        dnew[Symbol(k)] = v
+    end
+    return dnew
+end
+

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -37,6 +37,8 @@ import Base: getindex, setindex!, delete!, haskey, get, copy!, getproperty, setp
 @deprecate(setindex!(img::ImageMeta, X, propname::AbstractString),
            setproperty!(img, Symbol(propname), X))
 
+@deprecate(data(img::ImageMeta), arraydata(img))
+
 function to_dict(dold::AbstractDict{String})
     dnew = Dict{Symbol,Any}()
     for (k, v) in dold

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -14,7 +14,7 @@ function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{ImageMeta}}
             end
         end
         # Use the properties field of img to create the output
-        ret = ImageMeta(similar(Array{ElType}, axes(bc)), M.properties)
+        ret = ImageMeta(similar(Array{ElType}, axes(bc)), properties(M))
     else
         ret = ImageMeta(similar(Array{ElType}, axes(bc)))
     end

--- a/test/core.jl
+++ b/test/core.jl
@@ -154,7 +154,7 @@ end
 @testset "copy/similar" begin
     img = ImageMeta(rand(3,5); prop1 = 1, prop2 = [1,2,3])
     img2 = copy(img)
-    @test img2.data == img.data
+    @test data(img2) == data(img)
     img2[2,2] = -1
     @test img2[2,2] < 0
     @test img[2,2] >= 0
@@ -164,7 +164,7 @@ end
     img2 = similar(img)
     @test img2[:prop1] == 1
     @test img2[:prop2] == [1,2,3]
-    @test img2.data != img.data
+    @test data(img2) != data(img)
     img2[:prop3] = 7
     @test !haskey(img, :prop3)
     img2 = similar(img, RGB{Float16}, (Base.OneTo(5),))
@@ -172,7 +172,7 @@ end
     @test img2[:prop2] == [1,2,3]
     @test eltype(img2) == RGB{Float16}
     @test size(img2) == (5,)
-    @test img2.data != img.data
+    @test data(img2) != data(img)
     img2[:prop3] = 7
     @test !haskey(img, :prop3)
 
@@ -180,11 +180,11 @@ end
     B = ImageMeta(A, info="blah")
     C = similar(B)
     @test isa(C, ImageMeta)
-    @test isa(C.data, AxisArray)
+    @test isa(data(C), AxisArray)
     @test eltype(C) == Float64
     C = similar(B, RGB{Float16})
     @test isa(C, ImageMeta)
-    @test isa(C.data, AxisArray)
+    @test isa(data(C), AxisArray)
     @test eltype(C) == RGB{Float16}
 end
 
@@ -337,7 +337,7 @@ end
                     matrix=[1 3; 2 4],
                     tuple=(1,2))
     for imgp in (img', permutedims(img, (2,1)), permuteddimsview(img, (2,1)))
-        @test imgp.data == img.data'
+        @test data(imgp) == data(img)'
         @test imgp[:vector] == [2,1]
         @test imgp[:matrix] == [4 2; 3 1]
         @test imgp[:tuple]  == (2,1)
@@ -353,7 +353,7 @@ end
     @test ndims(Mp) == 2 && isa(Mp, ImageMeta)
 
     M = ImageMeta([1,2,3,4],
-                  spatialproperties=["vector"],
+                  spatialproperties=[:vector],
                   vector=[1])
     @test_throws ErrorException M'
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -34,10 +34,10 @@ using AxisArrays: AxisArray, axisnames, (..)
         @test A[3] == oneunit(eltype(A))
         @test_throws BoundsError img[0]
         @test_throws BoundsError img[4]
-        @test img[:prop1] == 1
-        @test img[:prop2] == [1,2,3]
-        img[:prop1] = -1
-        @test img[:prop1] == -1
+        @test img.prop1 == 1
+        @test img.prop2 == [1,2,3]
+        img.prop1 = -1
+        @test img.prop1 == -1
     end
     for A in (rand(3,5),
               view(rand(4,6), 1:3, 1:5),
@@ -73,10 +73,10 @@ using AxisArrays: AxisArray, axisnames, (..)
         @test_throws BoundsError img[0,0]
         @test_throws BoundsError img[4,1]
         @test_throws BoundsError img[1,6]
-        @test img[:prop1] == 1
-        @test img[:prop2] == [1,2,3]
-        img[:prop1] = -1
-        @test img[:prop1] == -1
+        @test img.prop1 == 1
+        @test img.prop2 == [1,2,3]
+        img.prop1 = -1
+        @test img.prop1 == -1
         # vector-indexing
         @test isa(@inferred(img[:,:]), ImageMeta) && img[:,:] == img
         @test isa(@inferred(img[:]), ImageMeta) && img[:] == A[:]
@@ -139,14 +139,14 @@ end
     M = ImageMeta(A, meta=true)
     Mr = reinterpretc(Gray, M)
     @test eltype(Mr) == Gray{Float32}
-    @test Mr[:meta] = true
+    @test Mr.meta = true
     # Ensure that it gets defined for the formerly un-reinterpretable
     A = zeros(Float32, 4, 5)
     M = ImageMeta(view(A, 1:2:3, 1:4), meta=true)
     Mr = reinterpretc(Gray, M)
     Mr = reinterpretc(Gray{Float32}, M)
     @test eltype(Mr) == Gray{Float32}
-    @test Mr[:meta] = true
+    @test Mr.meta = true
     Mr[:] .= Gray{Float32}(0.5)
     @test all(A[1:2:3,1:4] .== 0.5)
 end
@@ -158,23 +158,23 @@ end
     img2[2,2] = -1
     @test img2[2,2] < 0
     @test img[2,2] >= 0
-    img2[:prop2][2] = -2
-    @test img2[:prop2] == [1,-2,3]
-    @test img[:prop2] == [1,2,3]
+    img2.prop2[2] = -2
+    @test img2.prop2 == [1,-2,3]
+    @test img.prop2 == [1,2,3]
     img2 = similar(img)
-    @test img2[:prop1] == 1
-    @test img2[:prop2] == [1,2,3]
+    @test img2.prop1 == 1
+    @test img2.prop2 == [1,2,3]
     @test data(img2) != data(img)
-    img2[:prop3] = 7
-    @test !haskey(img, :prop3)
+    img2.prop3 = 7
+    @test !hasproperty(img, :prop3)
     img2 = similar(img, RGB{Float16}, (Base.OneTo(5),))
-    @test img2[:prop1] == 1
-    @test img2[:prop2] == [1,2,3]
+    @test img2.prop1 == 1
+    @test img2.prop2 == [1,2,3]
     @test eltype(img2) == RGB{Float16}
     @test size(img2) == (5,)
     @test data(img2) != data(img)
-    img2[:prop3] = 7
-    @test !haskey(img, :prop3)
+    img2.prop3 = 7
+    @test !hasproperty(img, :prop3)
 
     A = AxisArray(rand(3,5), :y, :x)
     B = ImageMeta(A, info="blah")
@@ -193,28 +193,28 @@ end
     @test !isempty(properties(img))
     v = view(img, 1:2, 1:2)
     c = img[1:2, 1:2]
-    @test v[:prop1] == 1
-    @test c[:prop1] == 1
+    @test v.prop1 == 1
+    @test c.prop1 == 1
     img2 = copyproperties(img, reshape(1:15, 5, 3))
     @test size(img2) == (5,3)
-    img2[:prop1] = -1
-    @test img[:prop1] == 1
+    img2.prop1 = -1
+    @test img.prop1 == 1
     img2 = shareproperties(img, reshape(1:15, 5, 3))
     @test size(img2) == (5,3)
-    img2[:prop1] = -1
-    @test img[:prop1] == -1
-    @test v[:prop1] == -1
-    @test c[:prop1] == 1
+    img2.prop1 = -1
+    @test img.prop1 == -1
+    @test v.prop1 == -1
+    @test c.prop1 == 1
     imgb = ImageMeta(rand(RGB{N0f8}, 2, 2), propa = "hello", propb = [1,2])
     copy!(img, imgb, :propa, :propb)
-    @test img[:propa] == "hello"
-    @test img[:propb] == [1,2]
-    img[:propb][2] = 10
-    @test img[:propb] == [1,10]
-    @test imgb[:propb] == [1,2]
+    @test img.propa == "hello"
+    @test img.propb == [1,2]
+    img.propb[2] = 10
+    @test img.propb == [1,10]
+    @test imgb.propb == [1,2]
     delete!(img, :propb)
-    @test  haskey(img, :propa)
-    @test !haskey(img, :propb)
+    @test  hasproperty(img, :propa)
+    @test !hasproperty(img, :propb)
 
     img = ImageMeta(AxisArray(rand(3,5,8),
                               Axis{:x}(1:3),
@@ -223,8 +223,8 @@ end
                     prop1 = 1, prop2 = [1,2,3])
     v = view(img, Axis{:time}(0.25..0.5))
     c = img[Axis{:time}(0.25..0.5)]
-    @test v[:prop1] == 1
-    @test c[:prop1] == 1
+    @test v.prop1 == 1
+    @test c.prop1 == 1
 end
 
 @testset "views" begin
@@ -233,7 +233,7 @@ end
         M1 = ImageMeta(A1, date=t1)
         vM1 = channelview(M1)
         @test isa(vM1, ImageMeta)
-        @test vM1[:date] == t1
+        @test vM1.date == t1
         @test data(vM1) == channelview(A1)
         @test isa(rawview(vM1), ImageMeta)
         if ndims(rawview(vM1)) == 3
@@ -259,12 +259,12 @@ end
     @test colordim(vM) == 1
     pvM = permutedims(vM, (2,3,1))
     @test colordim(pvM) == 3
-    @test pvM[:date] == t
+    @test pvM.date == t
     sleep(0.1)
-    pvM[:date] = now()
-    @test M[:date] == t && pvM[:date] != t
+    pvM.date = now()
+    @test M.date == t && pvM.date != t
     vM = permuteddimsview(M, (2,1))
-    @test vM[:date] == t
+    @test vM.date == t
     @test axisnames(vM) == (:x, :y)
 end
 
@@ -318,7 +318,7 @@ end
     @test @inferred(timedim(img)) == 3
     @test @inferred(pixelspacing(img)) === (1,1)
     @test spacedirections(img) === ((1,0),(0,1))
-    img[:spacedirections] = "broken"
+    img.spacedirections = "broken"
     @test spacedirections(img) == "broken"
     @test sdims(img) == 2
     @test @inferred(coords_spatial(img)) == (1,2)
@@ -338,12 +338,12 @@ end
                     tuple=(1,2))
     for imgp in (img', permutedims(img, (2,1)), permuteddimsview(img, (2,1)))
         @test data(imgp) == data(img)'
-        @test imgp[:vector] == [2,1]
-        @test imgp[:matrix] == [4 2; 3 1]
-        @test imgp[:tuple]  == (2,1)
-        @test img[:vector] == [1,2]
-        @test img[:matrix] == [1 3; 2 4]
-        @test img[:tuple]  == (1,2)
+        @test imgp.vector == [2,1]
+        @test imgp.matrix == [4 2; 3 1]
+        @test imgp.tuple  == (2,1)
+        @test img.vector == [1,2]
+        @test img.matrix == [1 3; 2 4]
+        @test img.tuple  == (1,2)
     end
 end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -34,10 +34,10 @@ using AxisArrays: AxisArray, axisnames, (..)
         @test A[3] == oneunit(eltype(A))
         @test_throws BoundsError img[0]
         @test_throws BoundsError img[4]
-        @test img["prop1"] == 1
-        @test img["prop2"] == [1,2,3]
-        img["prop1"] = -1
-        @test img["prop1"] == -1
+        @test img[:prop1] == 1
+        @test img[:prop2] == [1,2,3]
+        img[:prop1] = -1
+        @test img[:prop1] == -1
     end
     for A in (rand(3,5),
               view(rand(4,6), 1:3, 1:5),
@@ -73,10 +73,10 @@ using AxisArrays: AxisArray, axisnames, (..)
         @test_throws BoundsError img[0,0]
         @test_throws BoundsError img[4,1]
         @test_throws BoundsError img[1,6]
-        @test img["prop1"] == 1
-        @test img["prop2"] == [1,2,3]
-        img["prop1"] = -1
-        @test img["prop1"] == -1
+        @test img[:prop1] == 1
+        @test img[:prop2] == [1,2,3]
+        img[:prop1] = -1
+        @test img[:prop1] == -1
         # vector-indexing
         @test isa(@inferred(img[:,:]), ImageMeta) && img[:,:] == img
         @test isa(@inferred(img[:]), ImageMeta) && img[:] == A[:]
@@ -139,14 +139,14 @@ end
     M = ImageMeta(A, meta=true)
     Mr = reinterpretc(Gray, M)
     @test eltype(Mr) == Gray{Float32}
-    @test Mr["meta"] = true
+    @test Mr[:meta] = true
     # Ensure that it gets defined for the formerly un-reinterpretable
     A = zeros(Float32, 4, 5)
     M = ImageMeta(view(A, 1:2:3, 1:4), meta=true)
     Mr = reinterpretc(Gray, M)
     Mr = reinterpretc(Gray{Float32}, M)
     @test eltype(Mr) == Gray{Float32}
-    @test Mr["meta"] = true
+    @test Mr[:meta] = true
     Mr[:] .= Gray{Float32}(0.5)
     @test all(A[1:2:3,1:4] .== 0.5)
 end
@@ -158,23 +158,23 @@ end
     img2[2,2] = -1
     @test img2[2,2] < 0
     @test img[2,2] >= 0
-    img2["prop2"][2] = -2
-    @test img2["prop2"] == [1,-2,3]
-    @test img["prop2"] == [1,2,3]
+    img2[:prop2][2] = -2
+    @test img2[:prop2] == [1,-2,3]
+    @test img[:prop2] == [1,2,3]
     img2 = similar(img)
-    @test img2["prop1"] == 1
-    @test img2["prop2"] == [1,2,3]
+    @test img2[:prop1] == 1
+    @test img2[:prop2] == [1,2,3]
     @test img2.data != img.data
-    img2["prop3"] = 7
-    @test !haskey(img, "prop3")
+    img2[:prop3] = 7
+    @test !haskey(img, :prop3)
     img2 = similar(img, RGB{Float16}, (Base.OneTo(5),))
-    @test img2["prop1"] == 1
-    @test img2["prop2"] == [1,2,3]
+    @test img2[:prop1] == 1
+    @test img2[:prop2] == [1,2,3]
     @test eltype(img2) == RGB{Float16}
     @test size(img2) == (5,)
     @test img2.data != img.data
-    img2["prop3"] = 7
-    @test !haskey(img, "prop3")
+    img2[:prop3] = 7
+    @test !haskey(img, :prop3)
 
     A = AxisArray(rand(3,5), :y, :x)
     B = ImageMeta(A, info="blah")
@@ -193,28 +193,28 @@ end
     @test !isempty(properties(img))
     v = view(img, 1:2, 1:2)
     c = img[1:2, 1:2]
-    @test v["prop1"] == 1
-    @test c["prop1"] == 1
+    @test v[:prop1] == 1
+    @test c[:prop1] == 1
     img2 = copyproperties(img, reshape(1:15, 5, 3))
     @test size(img2) == (5,3)
-    img2["prop1"] = -1
-    @test img["prop1"] == 1
+    img2[:prop1] = -1
+    @test img[:prop1] == 1
     img2 = shareproperties(img, reshape(1:15, 5, 3))
     @test size(img2) == (5,3)
-    img2["prop1"] = -1
-    @test img["prop1"] == -1
-    @test v["prop1"] == -1
-    @test c["prop1"] == 1
+    img2[:prop1] = -1
+    @test img[:prop1] == -1
+    @test v[:prop1] == -1
+    @test c[:prop1] == 1
     imgb = ImageMeta(rand(RGB{N0f8}, 2, 2), propa = "hello", propb = [1,2])
-    copy!(img, imgb, "propa", "propb")
-    @test img["propa"] == "hello"
-    @test img["propb"] == [1,2]
-    img["propb"][2] = 10
-    @test img["propb"] == [1,10]
-    @test imgb["propb"] == [1,2]
-    delete!(img, "propb")
-    @test  haskey(img, "propa")
-    @test !haskey(img, "propb")
+    copy!(img, imgb, :propa, :propb)
+    @test img[:propa] == "hello"
+    @test img[:propb] == [1,2]
+    img[:propb][2] = 10
+    @test img[:propb] == [1,10]
+    @test imgb[:propb] == [1,2]
+    delete!(img, :propb)
+    @test  haskey(img, :propa)
+    @test !haskey(img, :propb)
 
     img = ImageMeta(AxisArray(rand(3,5,8),
                               Axis{:x}(1:3),
@@ -223,8 +223,8 @@ end
                     prop1 = 1, prop2 = [1,2,3])
     v = view(img, Axis{:time}(0.25..0.5))
     c = img[Axis{:time}(0.25..0.5)]
-    @test v["prop1"] == 1
-    @test c["prop1"] == 1
+    @test v[:prop1] == 1
+    @test c[:prop1] == 1
 end
 
 @testset "views" begin
@@ -233,7 +233,7 @@ end
         M1 = ImageMeta(A1, date=t1)
         vM1 = channelview(M1)
         @test isa(vM1, ImageMeta)
-        @test vM1["date"] == t1
+        @test vM1[:date] == t1
         @test data(vM1) == channelview(A1)
         @test isa(rawview(vM1), ImageMeta)
         if ndims(rawview(vM1)) == 3
@@ -259,12 +259,12 @@ end
     @test colordim(vM) == 1
     pvM = permutedims(vM, (2,3,1))
     @test colordim(pvM) == 3
-    @test pvM["date"] == t
+    @test pvM[:date] == t
     sleep(0.1)
-    pvM["date"] = now()
-    @test M["date"] == t && pvM["date"] != t
+    pvM[:date] = now()
+    @test M[:date] == t && pvM[:date] != t
     vM = permuteddimsview(M, (2,1))
-    @test vM["date"] == t
+    @test vM[:date] == t
     @test axisnames(vM) == (:x, :y)
 end
 
@@ -292,7 +292,7 @@ end
 end
 
 @testset "show" begin
-    for supp in (Set(["prop3"]), "prop3")
+    for supp in (Set([:prop3]), :prop3)
         img = ImageMeta(rand(3,5); prop1 = 1, prop2 = [1,2,3], suppress = supp, prop3 = "hide")
         str = string(img)
         @test occursin("ImageMeta with", str)
@@ -318,7 +318,7 @@ end
     @test @inferred(timedim(img)) == 3
     @test @inferred(pixelspacing(img)) === (1,1)
     @test spacedirections(img) === ((1,0),(0,1))
-    img["spacedirections"] = "broken"
+    img[:spacedirections] = "broken"
     @test spacedirections(img) == "broken"
     @test sdims(img) == 2
     @test @inferred(coords_spatial(img)) == (1,2)
@@ -332,18 +332,18 @@ end
 
 @testset "spatialprops" begin
     img = ImageMeta(rand(3,5),
-                    spatialproperties=Set(["vector","matrix","tuple"]),
+                    spatialproperties=Set([:vector,:matrix,:tuple]),
                     vector=[1,2],
                     matrix=[1 3; 2 4],
                     tuple=(1,2))
     for imgp in (img', permutedims(img, (2,1)), permuteddimsview(img, (2,1)))
         @test imgp.data == img.data'
-        @test imgp["vector"] == [2,1]
-        @test imgp["matrix"] == [4 2; 3 1]
-        @test imgp["tuple"]  == (2,1)
-        @test img["vector"] == [1,2]
-        @test img["matrix"] == [1 3; 2 4]
-        @test img["tuple"]  == (1,2)
+        @test imgp[:vector] == [2,1]
+        @test imgp[:matrix] == [4 2; 3 1]
+        @test imgp[:tuple]  == (2,1)
+        @test img[:vector] == [1,2]
+        @test img[:matrix] == [1 3; 2 4]
+        @test img[:tuple]  == (1,2)
     end
 end
 
@@ -387,11 +387,11 @@ end
                               Axis{:x}(1:3),
                               Axis{:y}(1:5),
                               Axis{:time}(0.1:0.1:0.8)),
-                    IdDict{String,Any}("pixelspacing" => (1,1)))
+                    IdDict{Symbol,Any}(:pixelspacing => (1,1)))
     @test @inferred(pixelspacing(img)) === (1,1)
 
     rand_img = rand(10,10)
-    dict = Dict("attr1" => 3, "attr2" => 4)
+    dict = Dict(:attr1 => 3, :attr2 => 4)
     @test ImageMeta(rand_img, dict)[1, 1] == rand_img[1, 1]
 end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -17,7 +17,7 @@ using AxisArrays: AxisArray, axisnames, (..)
         @test IndexStyle(img) == IndexStyle(A)
         @test ndims(img) == 1
         @test size(img) == (3,)
-        @test data(img) === A
+        @test arraydata(img) === A
         for i = 1:3
             @test @inferred(img[i]) === A[i]
         end
@@ -50,7 +50,7 @@ using AxisArrays: AxisArray, axisnames, (..)
         @test IndexStyle(img) == IndexStyle(A)
         @test ndims(img) == 2
         @test size(img) == (3,5)
-        @test data(img) === A
+        @test arraydata(img) === A
         for j = 1:5, i = 1:3
             @test @inferred(img[i,j]) === A[i,j]
         end
@@ -154,7 +154,7 @@ end
 @testset "copy/similar" begin
     img = ImageMeta(rand(3,5); prop1 = 1, prop2 = [1,2,3])
     img2 = copy(img)
-    @test data(img2) == data(img)
+    @test arraydata(img2) == arraydata(img)
     img2[2,2] = -1
     @test img2[2,2] < 0
     @test img[2,2] >= 0
@@ -164,7 +164,7 @@ end
     img2 = similar(img)
     @test img2.prop1 == 1
     @test img2.prop2 == [1,2,3]
-    @test data(img2) != data(img)
+    @test arraydata(img2) != arraydata(img)
     img2.prop3 = 7
     @test !hasproperty(img, :prop3)
     img2 = similar(img, RGB{Float16}, (Base.OneTo(5),))
@@ -172,7 +172,7 @@ end
     @test img2.prop2 == [1,2,3]
     @test eltype(img2) == RGB{Float16}
     @test size(img2) == (5,)
-    @test data(img2) != data(img)
+    @test arraydata(img2) != arraydata(img)
     img2.prop3 = 7
     @test !hasproperty(img, :prop3)
 
@@ -180,11 +180,11 @@ end
     B = ImageMeta(A, info="blah")
     C = similar(B)
     @test isa(C, ImageMeta)
-    @test isa(data(C), AxisArray)
+    @test isa(arraydata(C), AxisArray)
     @test eltype(C) == Float64
     C = similar(B, RGB{Float16})
     @test isa(C, ImageMeta)
-    @test isa(data(C), AxisArray)
+    @test isa(arraydata(C), AxisArray)
     @test eltype(C) == RGB{Float16}
 end
 
@@ -234,7 +234,7 @@ end
         vM1 = channelview(M1)
         @test isa(vM1, ImageMeta)
         @test vM1.date == t1
-        @test data(vM1) == channelview(A1)
+        @test arraydata(vM1) == channelview(A1)
         @test isa(rawview(vM1), ImageMeta)
         if ndims(rawview(vM1)) == 3
             @test rawview(vM1)[1,2,1] === rawview(channelview(A1))[1,2,1]
@@ -246,7 +246,7 @@ end
         M1 = ImageMeta(A1)
         vM1 = normedview(M1)
         @test isa(vM1, ImageMeta)
-        @test data(vM1) == normedview(A1)
+        @test arraydata(vM1) == normedview(A1)
         cvM = colorview(C, vM1)
         @test isa(cvM, ImageMeta)
         @test cvM[1,2] === colorview(C, normedview(A1))[1,2]
@@ -337,7 +337,7 @@ end
                     matrix=[1 3; 2 4],
                     tuple=(1,2))
     for imgp in (img', permutedims(img, (2,1)), permuteddimsview(img, (2,1)))
-        @test data(imgp) == data(img)'
+        @test arraydata(imgp) == arraydata(img)'
         @test imgp.vector == [2,1]
         @test imgp.matrix == [4 2; 3 1]
         @test imgp.tuple  == (2,1)

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -1,0 +1,129 @@
+@testset "Deprecations" begin
+    @testset "copy/similar" begin
+        img = ImageMeta(rand(3,5); prop1 = 1, prop2 = [1,2,3])
+        img2 = copy(img)
+        @test img2.data == img.data
+        img2[2,2] = -1
+        @test img2[2,2] < 0
+        @test img[2,2] >= 0
+        img2["prop2"][2] = -2
+        @test img2["prop2"] == [1,-2,3]
+        @test img["prop2"] == [1,2,3]
+        img2 = similar(img)
+        @test img2["prop1"] == 1
+        @test img2["prop2"] == [1,2,3]
+        @test img2.data != img.data
+        img2["prop3"] = 7
+        @test !haskey(img, "prop3")
+        img2 = similar(img, RGB{Float16}, (Base.OneTo(5),))
+        @test img2["prop1"] == 1
+        @test img2["prop2"] == [1,2,3]
+        @test eltype(img2) == RGB{Float16}
+        @test size(img2) == (5,)
+        @test img2.data != img.data
+        img2["prop3"] = 7
+        @test !haskey(img, "prop3")
+
+        A = AxisArray(rand(3,5), :y, :x)
+        B = ImageMeta(A, info="blah")
+        C = similar(B)
+        @test isa(C, ImageMeta)
+        @test isa(C.data, AxisArray)
+        @test eltype(C) == Float64
+        C = similar(B, RGB{Float16})
+        @test isa(C, ImageMeta)
+        @test isa(C.data, AxisArray)
+        @test eltype(C) == RGB{Float16}
+    end
+
+    @testset "copy/shareproperties/viewim" begin
+        img = ImageMeta(rand(3,5); prop1 = 1, prop2 = [1,2,3])
+        @test !isempty(properties(img))
+        v = view(img, 1:2, 1:2)
+        c = img[1:2, 1:2]
+        @test v["prop1"] == 1
+        @test c["prop1"] == 1
+        img2 = copyproperties(img, reshape(1:15, 5, 3))
+        @test size(img2) == (5,3)
+        img2["prop1"] = -1
+        @test img["prop1"] == 1
+        img2 = shareproperties(img, reshape(1:15, 5, 3))
+        @test size(img2) == (5,3)
+        img2["prop1"] = -1
+        @test img["prop1"] == -1
+        @test v["prop1"] == -1
+        @test c["prop1"] == 1
+        imgb = ImageMeta(rand(RGB{N0f8}, 2, 2), propa = "hello", propb = [1,2])
+        copy!(img, imgb, "propa", "propb")
+        @test img["propa"] == "hello"
+        @test img["propb"] == [1,2]
+        img["propb"][2] = 10
+        @test img["propb"] == [1,10]
+        @test imgb["propb"] == [1,2]
+        delete!(img, "propb")
+        @test  haskey(img, "propa")
+        @test !haskey(img, "propb")
+
+        img = ImageMeta(AxisArray(rand(3,5,8),
+                                  Axis{:x}(1:3),
+                                  Axis{:y}(1:5),
+                                  Axis{:time}(0.1:0.1:0.8));
+                        prop1 = 1, prop2 = [1,2,3])
+        v = view(img, Axis{:time}(0.25..0.5))
+        c = img[Axis{:time}(0.25..0.5)]
+        @test v["prop1"] == 1
+        @test c["prop1"] == 1
+    end
+
+    @testset "traits" begin
+        img = ImageMeta(AxisArray(rand(3,5,8),
+                                  Axis{:x}(1:3),
+                                  Axis{:y}(1:5),
+                                  Axis{:time}(0.1:0.1:0.8)))
+        @test @inferred(timedim(img)) == 3
+        @test @inferred(pixelspacing(img)) === (1,1)
+        @test spacedirections(img) === ((1,0),(0,1))
+        img["spacedirections"] = "broken"
+        @test spacedirections(img) == "broken"
+        @test sdims(img) == 2
+        @test @inferred(coords_spatial(img)) == (1,2)
+        @test spatialorder(img) == (:x, :y)
+        @test nimages(img) == 8
+        @test @inferred(size_spatial(img)) == (3,5)
+        @test @inferred(indices_spatial(img)) == (Base.OneTo(3), Base.OneTo(5))
+        assert_timedim_last(img)
+        @test timeaxis(img) == Axis{:time}(0.1:0.1:0.8)
+    end
+
+    @testset "spatialprops" begin
+        img = ImageMeta(rand(3,5),
+                        spatialproperties=Set(["vector","matrix","tuple"]),
+                        vector=[1,2],
+                        matrix=[1 3; 2 4],
+                        tuple=(1,2))
+        for imgp in (img', permutedims(img, (2,1)), permuteddimsview(img, (2,1)))
+            @test imgp.data == img.data'
+            @test imgp["vector"] == [2,1]
+            @test imgp["matrix"] == [4 2; 3 1]
+            @test imgp["tuple"]  == (2,1)
+            @test img["vector"] == [1,2]
+            @test img["matrix"] == [1 3; 2 4]
+            @test img["tuple"]  == (1,2)
+        end
+    end
+
+    @testset "AbstractDicts" begin
+        img = ImageMeta(AxisArray(rand(3,5,8),
+                                  Axis{:x}(1:3),
+                                  Axis{:y}(1:5),
+                                  Axis{:time}(0.1:0.1:0.8)),
+                        IdDict{String,Any}("pixelspacing" => (1,1)))
+        @test @inferred(pixelspacing(img)) === (1,1)
+
+        rand_img = rand(10,10)
+        dict = Dict("attr1" => 3, "attr2" => 4)
+        @test ImageMeta(rand_img, dict)[1, 1] == rand_img[1, 1]
+    end
+end
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,3 +16,4 @@ end
 
 include("core.jl")
 include("operations.jl")
+include("deprecations.jl")


### PR DESCRIPTION
This PR is motivated primarily by the conversation found here https://github.com/JuliaNeuroscience/NeuroCore.jl/pull/1#discussion_r358588789. I couldn't resist adding in all of the property methods so there are a bit more changes than the initial commit. However, now there's tab completion for properties.

Here's a summary of changes:

* `AbstractDict{String,Any}` -> `AbstractDict{Symbol,Any}`
* `getindex(::ImageMeta, ::AbstractString)` -> `getproperty(::ImageMeta, ::Symbol)`
* `setindex!(::ImageMeta, X, ::AbstractString)` -> `setproperty!(::ImageMeta, ::Symbol, X)`
* `haskey(::ImageMeta, ::AbstractString)` -> `hasproperty(::ImageMeta, ::Symbol)`
* `get(::ImageMeta, ::AbstractString, default)` -> `get(::ImageMeta, ::Symbol, default)`

I kept `get` around because I thought it might be useful to have a method of providing
a default returned value.
