### PR TITLE
Fix `convert` methods, circumvent colorspace conversion depwarns in tests

### DIFF
--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -165,8 +165,9 @@ Base.copy(img::ImageMeta) = ImageMeta(copy(arraydata(img)), deepcopy(properties(
 Base.convert(::Type{ImageMeta}, A::ImageMeta) = A
 Base.convert(::Type{ImageMeta}, A::AbstractArray) = ImageMeta(A)
 Base.convert(::Type{ImageMeta{T}}, A::ImageMeta{T}) where {T} = A
-Base.convert(::Type{ImageMeta{T}}, A::ImageMeta) where {T} = shareproperties(A, convert(Array{T}, arraydata(A)))
-Base.convert(::Type{ImageMeta{T}}, A::AbstractArray) where {T} = ImageMeta(convert(Array{T}, A))
+Base.convert(::Type{ImageMeta{T}}, A::ImageMeta) where {T} = shareproperties(A, convert(AbstractArray{T}, arraydata(A)))
+Base.convert(::Type{ImageMeta{T}}, A::AbstractArray{T}) where {T} = ImageMeta(A)
+Base.convert(::Type{ImageMeta{T}}, A::AbstractArray) where {T} = ImageMeta(convert(AbstractArray{T}, A))
 
 # copy properties
 function Base.copy!(imgdest::ImageMeta, imgsrc::ImageMeta, prop1::Symbol, props::Symbol...)

--- a/test/core.jl
+++ b/test/core.jl
@@ -128,9 +128,10 @@ end
     @test convert(ImageMeta, M) === M
     @test convert(ImageMeta{Float64}, M) === M
     @test eltype(convert(ImageMeta{Gray{Float64}}, M)) == Gray{Float64}
-    @test eltype(convert(ImageMeta{Gray}, M)) == Gray{Float64}
-    @test convert(ImageMeta{Gray}, M) == M
-    @test convert(ImageMeta{Gray}, A) == A
+    metagray = Gray.(M)
+    @test eltype(metagray) == Gray{Float64} && isa(metagray, ImageMeta)
+    @test convert(ImageMeta{Gray{Float64}}, M) == M
+    @test convert(ImageMeta{Gray{Float64}}, A) == A
 end
 
 @testset "reinterpret" begin


### PR DESCRIPTION
There was no good reason that these convert methods should have converted the data array to `Array`.