### PR TITLE
permuteddimsview -> PermutedDimsArray

### DIFF
--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -240,9 +240,9 @@ See also: [`properties`](@ref).
 """
 ImageAxes.arraydata(img::ImageMeta) = getfield(img, :data)
 
-function ImageCore.permuteddimsview(A::ImageMeta, perm)
+function ImageCore.PermutedDimsArray(A::ImageMeta, perm)
     ip = sortperm([perm...][[coords_spatial(A)...]])  # the inverse spatial permutation
-    permutedims_props!(copyproperties(A, permuteddimsview(arraydata(A), perm)), ip)
+    permutedims_props!(copyproperties(A, PermutedDimsArray(arraydata(A), perm)), ip)
 end
 ImageCore.channelview(A::ImageMeta) = shareproperties(A, channelview(arraydata(A)))
 ImageCore.colorview(::Type{C}, A::ImageMeta{T,N}) where {C<:Colorant,T,N} = shareproperties(A, colorview(C, arraydata(A)))

--- a/src/ImageMetadata.jl
+++ b/src/ImageMetadata.jl
@@ -240,7 +240,7 @@ See also: [`properties`](@ref).
 """
 ImageAxes.arraydata(img::ImageMeta) = getfield(img, :data)
 
-function ImageCore.PermutedDimsArray(A::ImageMeta, perm)
+function Base.PermutedDimsArray(A::ImageMeta, perm)
     ip = sortperm([perm...][[coords_spatial(A)...]])  # the inverse spatial permutation
     permutedims_props!(copyproperties(A, PermutedDimsArray(arraydata(A), perm)), ip)
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -264,7 +264,7 @@ end
     sleep(0.1)
     pvM.date = now()
     @test M.date == t && pvM.date != t
-    vM = permuteddimsview(M, (2,1))
+    vM = PermutedDimsArray(M, (2,1))
     @test vM.date == t
     @test axisnames(vM) == (:x, :y)
 end
@@ -337,7 +337,7 @@ end
                     vector=[1,2],
                     matrix=[1 3; 2 4],
                     tuple=(1,2))
-    for imgp in (img', permutedims(img, (2,1)), permuteddimsview(img, (2,1)))
+    for imgp in (img', permutedims(img, (2,1)), PermutedDimsArray(img, (2,1)))
         @test arraydata(imgp) == arraydata(img)'
         @test imgp.vector == [2,1]
         @test imgp.matrix == [4 2; 3 1]


### PR DESCRIPTION
## Before Change
On a Jupyter notebook with Julia 1.4.2, Images v0.22.4 (specifically with ImageAxes v0.6.5 and ImageMetadata v0.9.2):

```
using Images

┌ Info: Precompiling Images [916415d5-f1e6-5110-898d-aaa5f9f070e0]
└ @ Base loading.jl:1260
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/ImageAxes/ppqC3/src/ImageAxes.jl:114
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/ImageMetadata/Ss1Hl/src/ImageMetadata.jl:243
```

```
x= rand(1, 40, 40, 1)
colorview(Gray, x[1, :, :, 1])

┌ Info: Precompiling PNGFiles [f57f5aa1-a3ce-4bc8-8ab9-96f992907883]
└ @ Base loading.jl:1260
┌ Info: Precompiling ImageMagick [6218d12a-5da1-5696-b52f-db25d2ecc6d1]
└ @ Base loading.jl:1260

WARNING: importing deprecated binding ImageCore.permuteddimsview into ImageAxes.
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: importing deprecated binding ImageCore.permuteddimsview into ImageMetadata.
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
WARNING: ImageCore.permuteddimsview is deprecated, use PermutedDimsArray instead.
  likely near /home/vtjeng/.julia/packages/IJulia/tOM8L/src/kernel.jl:52
```

## After Change
Along with https://github.com/JuliaImages/ImageAxes.jl/pull/50
```
using Images

┌ Info: Precompiling Images [916415d5-f1e6-5110-898d-aaa5f9f070e0]
└ @ Base loading.jl:1260

x= rand(1, 40, 40, 1)
colorview(Gray, x[1, :, :, 1])
```